### PR TITLE
feat(web): Add row numbering in "all votes" view

### DIFF
--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -62,6 +62,7 @@
                     <table id="allProposals" class="table table-bordered table-hover table-condensed">
                         <thead>
                             <tr>
+                                <th/>
                                 <th>Average</th>
                                 <th>Nb of votes</th>
                                 <th>Nb of abstention</th>
@@ -80,6 +81,7 @@
                                 @defining(ApprovedProposal.isRefused(proposal.id, proposal.talkType.id)){refused=>
                                 @defining(ApprovedProposal.isApproved(proposal.id, proposal.talkType.id)){approved=>
                                 <tr class="preselected_@approved refused_@refused">
+                                    <td class="number_table"/>
                                     <td class="average_table">
                                     @defining(voteAndTotalVotes._4) { average =>
                                        @average
@@ -168,22 +170,22 @@
     $.fn.dataTableExt.oStdClasses.sStripeEven = '';
 
     $('#allProposals').dataTable({
-    "aaSorting": [[ 0, "desc" ]],
+    "aaSorting": [[ 1, "desc" ]],
     "iDisplayLength": 75,
     "aLengthMenu": [[5, 10, 25, 50, 75, 100, -1], [5,10,25, 50, 75,100, "All"]],
     "bStateSave": true,
-    "aoColumns": [
-        { "sType": "numeric"},
-        { "sType": "numeric"},
-        { "sType": "numeric"},
-        { "sType": "numeric"},
-        { "sType": "string"},
-        { "sType": "string"},
-        { "sType": "string"},
-        { "sType": "string"},
-        { "sType": "string"},
-        { "sType": "string"},
-        { "sType": "string"}
+    "fnDrawCallback": function ( oSettings ) {
+            /* Need to redo the counters if filtered or sorted */
+            if ( oSettings.bSorted || oSettings.bFiltered ) {
+                for ( var i=0, iLen=oSettings.aiDisplay.length ; i<iLen ; i++ ) {
+                    $('td:eq(0)', oSettings.aoData[ oSettings.aiDisplay[i] ].nTr ).html( i+1 );
+                }
+            }
+        },
+    "aoColumnsDef": [
+        { "bSortable" : "false", "bSearchable" : "false", "aTargets": 0 },
+        { "sType": "numeric", "aTargets": [1, 2, 3, 4]},
+        { "sType": "string", "aTargets": [5, 6, 7, 8, 9, 10, 11]}
         ]
     });
 


### PR DESCRIPTION
During Devoxx BE 2015, reviewers requested that row numbers be shown in the "all votes" view in
order to improve readability. It is added as the first column of the table, preserving default
ordering on the "average" column.
