### PR TITLE
fix(api): Do not wrap ids in a Messages() call

### DIFF
--- a/app/controllers/RestAPI.scala
+++ b/app/controllers/RestAPI.scala
@@ -266,7 +266,7 @@ object RestAPI extends Controller {
                   "summary" -> Json.toJson(proposal.summary),
                   "summaryAsHtml" -> Json.toJson(proposal.summaryAsHtml),
                   "track" -> Json.toJson(Messages(proposal.track.label)),
-                  "trackId" -> Json.toJson(Messages(proposal.track.id)),
+                  "trackId" -> Json.toJson(proposal.track.id),
                   "speakers" -> Json.toJson(allSpeakers.map {
                     speaker =>
                       Map(
@@ -418,7 +418,7 @@ object RestAPI extends Controller {
                       "summaryAsHtml" -> Json.toJson(proposal.summaryAsHtml),
                       "summary" -> Json.toJson(proposal.summary),
                       "track" -> Json.toJson(Messages(proposal.track.label)),
-                      "trackId" -> Json.toJson(Messages(proposal.track.id)),
+                      "trackId" -> Json.toJson(proposal.track.id),
                       "talkType" -> Json.toJson(Messages(proposal.talkType.id)),
                       "speakers" -> Json.toJson(allSpeakers.map {
                         speaker =>
@@ -591,7 +591,7 @@ object RestAPI extends Controller {
                       "summaryAsHtml" -> Json.toJson(proposal.summaryAsHtml),
                       "summary" -> Json.toJson(proposal.summary),
                       "track" -> Json.toJson(Messages(proposal.track.label)),
-                      "trackId" -> Json.toJson(Messages(proposal.track.id)),
+                      "trackId" -> Json.toJson(proposal.track.id),
                       "talkType" -> Json.toJson(Messages(proposal.talkType.id)),
                       "speakers" -> Json.toJson(allSpeakers.map {
                         speaker =>


### PR DESCRIPTION
The track id exposed by the RestAPI was wrapped in a Messages(id)
call and unfortunately there is currently a "lang" entry in the
messages.
The fix makes the API now return simply the id, which will allow the
"lang" track to be recognized.
