### PR TITLE
fix(api): Show only accepted talks for speaker

### DIFF
--- a/app/controllers/RestAPI.scala
+++ b/app/controllers/RestAPI.scala
@@ -192,7 +192,7 @@ object RestAPI extends Controller {
               NotModified
             }
             case other => {
-              val acceptedProposals = ApprovedProposal.allApprovedTalksForSpeaker(speaker.uuid)
+              val acceptedProposals = ApprovedProposal.allAcceptedTalksForSpeaker(speaker.uuid)
 
               val updatedTalks = acceptedProposals.map {
                 proposal: Proposal =>

--- a/app/models/ApprovedProposal.scala
+++ b/app/models/ApprovedProposal.scala
@@ -306,11 +306,17 @@ object ApprovedProposal {
       }
   }
 
+  // Talks approved by the program committee
   def allApprovedTalksForSpeaker(speakerId: String): Iterable[Proposal] = Redis.pool.withClient {
     implicit client =>
       val allApprovedProposals = client.smembers("ApprovedSpeakers:" + speakerId)
       val mapOfProposals = Proposal.loadAndParseProposals(allApprovedProposals)
       mapOfProposals.values
+  }
+
+  // Talks for wich speakers confirmed he will present
+  def allAcceptedTalksForSpeaker(speakerId: String): Iterable[Proposal] = {
+    allApprovedTalksForSpeaker(speakerId).filter(_.state == ProposalState.ACCEPTED).toList
   }
 
   def allAcceptedByTalkType(talkType: String): List[Proposal] = Redis.pool.withClient {


### PR DESCRIPTION
The RestAPI.showSpeaker endpoint was listing talks that had been
approved but possible later declined or refused. This change limits
the talks displayed to the ones in accepted state.
