### PR TITLE
fix(api): Properly prefix twitter handle with @ when missing

### DIFF
--- a/app/controllers/RestAPI.scala
+++ b/app/controllers/RestAPI.scala
@@ -231,7 +231,7 @@ object RestAPI extends Controller {
                   "lang" -> speaker.lang.map(u => Json.toJson(u.trim())).getOrElse(Json.toJson("fr")),
                   "bio" -> Json.toJson(speaker.bio),
                   "bioAsHtml" -> Json.toJson(speaker.bioAsHtml),
-                  "twitter" -> speaker.twitter.map(u => Json.toJson(u.trim())).getOrElse(JsNull),
+                  "twitter" -> speaker.cleanTwitter.map(Json.toJson(_)).getOrElse(JsNull),
                   "acceptedTalks" -> Json.toJson(updatedTalks)
                 )
 

--- a/app/models/Speaker.scala
+++ b/app/models/Speaker.scala
@@ -76,6 +76,16 @@ case class Speaker(uuid: String
       }
   }.getOrElse("fr")
 
+  def cleanTwitter: Option[String] = twitter.map {
+    tw =>
+      val trimmed = tw.trim()
+      if (!trimmed.startsWith("@")) {
+        "@" + trimmed
+      } else {
+        trimmed
+      }
+  }
+
 
   def hasTwitter = StringUtils.trimToEmpty(twitter.getOrElse("")).nonEmpty
 

--- a/app/views/Publisher/showSpeaker.scala.html
+++ b/app/views/Publisher/showSpeaker.scala.html
@@ -7,7 +7,7 @@
          @speaker.avatarUrl.map{url=>
             <img class="speakerRound"  src="@url"  alt="@speaker.cleanName" title="@speaker.cleanName"><br>
         }
-        @speaker.twitter.map{tw=>
+        @speaker.cleanTwitter.map{tw=>
         <a href="http://www.twitter.com/@tw" rel="no-follow" class="speakerTwitter">
         }
         @speaker.cleanName


### PR DESCRIPTION
As reported by mobile app developers, some speakers have a twitter handle that misses the leading
 '@'.
Speaker type now has a cleanTwitter method that takes care of trimming and prepending the missing @
 if needed.
