### PR TITLE
chore: Fix the play framework dependency on docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
    expose:
      - 6379
   play:
-    image: alexproca/play:2.2.3
+    image: ifinavet/playframework:2.2.3
     volumes:
       - .:/app:rw
     ports:


### PR DESCRIPTION
The repository [alexproca/play:2.2.3](https://hub.docker.com/r/alexproca/play/) is not maintained anymore. And there is no alternative on Alex's profile.
[ifinavet/playframework:2.2.3](https://hub.docker.com/r/ifinavet/playframework/) does the same thing and seems pretty well organised.