### PR TITLE
Fixes #101 by changing the from mail header

### DIFF
--- a/app/models/ConferenceDescriptor.scala
+++ b/app/models/ConferenceDescriptor.scala
@@ -686,7 +686,7 @@ object ConferenceDescriptor {
     confUrlCode = "devoxxfr2018",
     frLangEnabled = true,
     fromEmail = Play.current.configuration.getString("mail.from").getOrElse("program@devoxx.fr"),
-    committeeEmail = Play.current.configuration.getString("mail.committee.email").getOrElse("program@devoxx.fr"),
+    committeeEmail = Play.current.configuration.getString("mail.committee.email").getOrElse("program+notifications@devoxx.fr"),
     bccEmail = Play.current.configuration.getString("mail.bcc"),
     bugReportRecipient = Play.current.configuration.getString("mail.bugreport.recipient").getOrElse("nicolas.martignole@devoxx.fr"),
     conferenceUrls = ConferenceUrls(


### PR DESCRIPTION
Filtering is hard when both the mailing list and the cfp send mails 
**from** `program@devoxx.fr`. This PR intends to fix that by using 
the [gmail plus sign feature](https://gmail.googleblog.com/2008/03/2-hidden-ways-to-get-more-from-your.html).