### PR TITLE
Fix docker-compose and readme about docker-connection to redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,17 @@ A docker compose file is provided with Redis and Elastic Search configuration.
 
 To connect to your local Redis Cli, you can use this command line as an example :
 
-```docker run -it --link cfpdevoxx_redis_1:redis --rm redis sh -c 'exec redis-cli -h "$REDIS_PORT_6379_TCP_ADDR" -p "$REDIS_PORT_6379_TCP_PORT"'``
+```sudo docker exec -it cfp-devoxx_redis redis-cli```
+
+Note: The vm.max_map_count kernel setting needs to be set to at least 262144.
+ - On linux: `sudo sysctl -w vm.max_map_count=262144`
+ - On Mac OS: `sysctl -w vm.max_map_count=262144`
+ - On Windows and MacOS with docker toolbox:
+ ```
+ docker-machine ssh
+ sudo sysctl -w vm.max_map_count=262144
+ ```
+ See [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-prod-mode) for more details.
 
 ## Here's what you need to configure:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 version: '2'
 services:
   elasticsearch:
-   image: elasticsearch
+   image: elasticsearch:6.5.4
    expose:
      - 9200
   redis:
+   container_name: cfp-devoxx_redis
    image : redis:2.8.21
    expose:
      - 6379
@@ -24,3 +25,5 @@ services:
     env_file:
       - run.env
     command: play run
+
+    


### PR DESCRIPTION
Fix docker-compose
    
     * Add a version to elasticseach
     * Add a container_name to redis to be able to call it more easily

Fix README about docker-compose connection to redis