### PR TITLE
[fix] /admin/tags/selection and /admin/tags are failing with NoSuchEl…

### DIFF
--- a/app/models/Tags.scala
+++ b/app/models/Tags.scala
@@ -61,8 +61,10 @@ object Tags {
 
         // Create TagProposalEntries
         proposals.foreach(proposalId => {
-          foundTags.add(createTagProposalEntry(Tag.findById(tagId).get,
-                                               Proposal.findById(proposalId).get))
+          val proposalOpt = Proposal.findById(proposalId)
+          if(proposalOpt.isDefined){
+            foundTags.add(createTagProposalEntry(Tag.findById(tagId).get, proposalOpt.get))
+          }
         })
       })
 


### PR DESCRIPTION
…ementException: None.get`

```
play.api.Application$$anon$1: Execution exception[[NoSuchElementException: None.get]]
	at play.api.Application$class.handleError(Application.scala:296)
	at play.api.DefaultApplication.handleError(Application.scala:402)
	at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$14$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:205)
	at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$14$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:202)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:36)
	at scala.util.Failure$$anonfun$recover$1.apply(Try.scala:215)
	at scala.util.Try$.apply(Try.scala:191)
	at scala.util.Failure.recover(Try.scala:215)
	at scala.concurrent.Future$$anonfun$recover$1.apply(Future.scala:324)
	at scala.concurrent.Future$$anonfun$recover$1.apply(Future.scala:324)
Caused by: java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:347)
	at scala.None$.get(Option.scala:345)
	at models.Tags$$anonfun$allProposals$1$$anonfun$apply$3$$anonfun$apply$4.apply(Tags.scala:65)
	at models.Tags$$anonfun$allProposals$1$$anonfun$apply$3$$anonfun$apply$4.apply(Tags.scala:63)
	at scala.collection.immutable.Set$Set1.foreach(Set.scala:79)
	at models.Tags$$anonfun$allProposals$1$$anonfun$apply$3.apply(Tags.scala:63)
	at models.Tags$$anonfun$allProposals$1$$anonfun$apply$3.apply(Tags.scala:55)
	at scala.collection.immutable.HashSet$HashSet1.foreach(HashSet.scala:322)
	at scala.collection.immutable.HashSet$HashTrieSet.foreach(HashSet.scala:978)
	at scala.collection.immutable.HashSet$HashTrieSet.foreach(HashSet.scala:978)
```

It's strange this error @nicmarti 

We didn't have this problem last year.
I don't understand how we could have a non-existing proposal 
