### PR TITLE
Fix 2020 dates

### DIFF
--- a/app/models/ConferenceDescriptor.scala
+++ b/app/models/ConferenceDescriptor.scala
@@ -702,9 +702,9 @@ object ConferenceDescriptor {
       firstDayEn = "april 15th",
       datesFr = "du 15 au 17 avril 2020",
       datesEn = "from 15th to 17th of April, 2020",
-      cfpOpenedOn = DateTime.parse("2019-12-01T00:00:00+02:00"),
-      cfpClosedOn = DateTime.parse("2020-01-16T23:59:00+02:00"),
-      scheduleAnnouncedOn = DateTime.parse("2020-02-15T00:00:00+02:00"),
+      cfpOpenedOn = DateTime.parse("2019-12-02T00:00:00+02:00"),
+      cfpClosedOn = DateTime.parse("2020-01-12T23:59:59+02:00"),
+      scheduleAnnouncedOn = DateTime.parse("2020-03-01T00:00:00+02:00"),
       days = dateRange(fromDay, toDay, new Period().withDays(1))
     ),
     hosterName = "Clever-cloud", hosterWebsite = "http://www.clever-cloud.com/#DevoxxFR",


### PR DESCRIPTION
* The CFP opens on December 2nd (Monday)
* It closes on January 12th (Sunday EOD)
* Publication of the agenda will be on March 1st - at the later (speakers will notified after Feb 6th)