### PR TITLE
Make the search results box not hidden behind other elements

### DIFF
--- a/app/assets/css/cfp.less
+++ b/app/assets/css/cfp.less
@@ -111,6 +111,7 @@ dd.info {
   background-color: #fff;
   display: none;
   font-size: 13px;
+  z-index: 1;
 }
 
 .searching {


### PR DESCRIPTION
It solves this issue:

![2019-12-19-064024_456x302_scrot](https://user-images.githubusercontent.com/537567/71147749-0d941200-222a-11ea-8185-232c1580c87c.png)
