### PR TITLE
Next talk ui improvement : new button for same track + format

### DIFF
--- a/app/controllers/CFPAdmin.scala
+++ b/app/controllers/CFPAdmin.scala
@@ -117,9 +117,13 @@ object CFPAdmin extends SecureCFPController {
 
             // The next proposal I should review
             val allNotReviewed = Review.allProposalsNotReviewed(uuid)
+            val (sameTrackAndFormats, otherTracksOrFormats) = allNotReviewed.partition(p => p.track.id == proposal.track.id && p.talkType.id == proposal.talkType.id)
             val (sameTracks, otherTracks) = allNotReviewed.partition(_.track.id == proposal.track.id)
             val (sameTalkType, otherTalksType) = allNotReviewed.partition(_.talkType.id == proposal.talkType.id)
 
+            // Note: not appending otherTracksOrFormats here, as we want to show the button in the
+            // template only if there are some remaining talks to be reviewed for same track & talkType
+            val nextToBeReviewedSameTrackAndFormat = (sameTrackAndFormats.sortBy(_.track.id)).headOption
             val nextToBeReviewedSameTrack = (sameTracks.sortBy(_.talkType.id) ++ otherTracks).headOption
             val nextToBeReviewedSameFormat = (sameTalkType.sortBy(_.track.id) ++ otherTalksType).headOption
 
@@ -163,9 +167,9 @@ object CFPAdmin extends SecureCFPController {
             if (ConferenceDescriptor.isGoldenTicketActive) {
               val averageScoreGT = ReviewByGoldenTicket.averageScore(proposalId)
               val countVotesCastGT: Option[Long] = Option(ReviewByGoldenTicket.totalVoteCastFor(proposalId))
-              Ok(views.html.CFPAdmin.showVotesForProposal(uuid, proposal, currentAverageScore, countVotesCast, countVotes, allVotes, nextToBeReviewedSameTrack, nextToBeReviewedSameFormat, averageScoreGT, countVotesCastGT, meAndMyFollowers))
+              Ok(views.html.CFPAdmin.showVotesForProposal(uuid, proposal, currentAverageScore, countVotesCast, countVotes, allVotes, nextToBeReviewedSameTrackAndFormat, nextToBeReviewedSameTrack, nextToBeReviewedSameFormat, averageScoreGT, countVotesCastGT, meAndMyFollowers))
             } else {
-              Ok(views.html.CFPAdmin.showVotesForProposal(uuid, proposal, currentAverageScore, countVotesCast, countVotes, allVotes, nextToBeReviewedSameTrack, nextToBeReviewedSameFormat, 0, None, meAndMyFollowers))
+              Ok(views.html.CFPAdmin.showVotesForProposal(uuid, proposal, currentAverageScore, countVotesCast, countVotes, allVotes, nextToBeReviewedSameTrackAndFormat, nextToBeReviewedSameTrack, nextToBeReviewedSameFormat, 0, None, meAndMyFollowers))
             }
           case None => NotFound("Proposal not found").as("text/html")
         }

--- a/app/controllers/GoldenTicketController.scala
+++ b/app/controllers/GoldenTicketController.scala
@@ -168,13 +168,17 @@ object GoldenTicketController extends SecureCFPController {
           case Some(proposal) =>
             // The next proposal I should review
             val allNotReviewed = ReviewByGoldenTicket.allProposalsNotReviewed(uuid)
+            val (sameTrackAndFormats, otherTracksOrFormats) = allNotReviewed.partition(p => p.track.id == proposal.track.id && p.talkType.id == proposal.talkType.id)
             val (sameTracks, otherTracks) = allNotReviewed.partition(_.track.id == proposal.track.id)
             val (sameTalkType, otherTalksType) = allNotReviewed.partition(_.talkType.id == proposal.talkType.id)
 
+            // Note: not appending otherTracksOrFormats here, as we want to show the button in the
+            // template only if there are some remaining talks to be reviewed for same track & talkType
+            val nextToBeReviewedSameTrackAndFormat = (sameTrackAndFormats.sortBy(_.track.id)).headOption
             val nextToBeReviewedSameTrack = (sameTracks.sortBy(_.talkType.id) ++ otherTracks).headOption
             val nextToBeReviewedSameFormat = (sameTalkType.sortBy(_.track.id) ++ otherTalksType).headOption
 
-            Ok(views.html.GoldenTicketController.showVotesForProposal(uuid, proposal, nextToBeReviewedSameTrack, nextToBeReviewedSameFormat))
+            Ok(views.html.GoldenTicketController.showVotesForProposal(uuid, proposal, nextToBeReviewedSameTrackAndFormat, nextToBeReviewedSameTrack, nextToBeReviewedSameFormat))
           case None => NotFound("Proposal not found").as("text/html")
         }
       }

--- a/app/views/CFPAdmin/showVotesForProposal.scala.html
+++ b/app/views/CFPAdmin/showVotesForProposal.scala.html
@@ -172,10 +172,10 @@
                         @if(nextToBeReviewedSameTrack.nonEmpty) {
                             @if(nextToBeReviewedSameTrack.head.track.id == proposal.track.id) {
                                 <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
-                                    @Messages("gt.nextTalkTrack" , Messages(nextToBeReviewedSameTrack.head.track.label))</a>
+                                    @Messages("gt.nextTalkTrack", Messages(nextToBeReviewedSameTrack.head.track.label))</a>
                             } else {
                                 <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
-                                    @Messages("gt.nextTalk")</a>
+                                    @Messages("gt.nextTalkDifferentTrack", Messages(nextToBeReviewedSameTrack.head.track.label))</a>
                             }
                         }
                         @if(nextToBeReviewedSameFormat.nonEmpty) {
@@ -184,7 +184,7 @@
                                     @Messages("gt.nextTalkType", Messages(proposal.talkType.id))</a>
                             } else {
                                 <a class="btn btn-success" accesskey="l" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
-                                    @Messages("gt.nextTalk")</a>
+                                    @Messages("gt.nextTalkDifferentType", Messages(nextToBeReviewedSameTrack.head.talkType.id))</a>
                             }
                         }
                     </div>

--- a/app/views/CFPAdmin/showVotesForProposal.scala.html
+++ b/app/views/CFPAdmin/showVotesForProposal.scala.html
@@ -180,10 +180,10 @@
                         }
                         @if(nextToBeReviewedSameFormat.nonEmpty) {
                             @if(nextToBeReviewedSameFormat.head.talkType.id == proposal.talkType.id) {
-                                <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameFormat.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
+                                <a class="btn btn-success" accesskey="l" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameFormat.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
                                     @Messages("gt.nextTalkType", Messages(proposal.talkType.id))</a>
                             } else {
-                                <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
+                                <a class="btn btn-success" accesskey="l" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
                                     @Messages("gt.nextTalk")</a>
                             }
                         }

--- a/app/views/CFPAdmin/showVotesForProposal.scala.html
+++ b/app/views/CFPAdmin/showVotesForProposal.scala.html
@@ -169,7 +169,7 @@
                                 @Messages("no.more.talk")</a>
                         }
                         <br>
-                        @if(nextToBeReviewedSameTrack.nonEmpty && nextToBeReviewedSameFormat.nonEmpty) {
+                        @if(nextToBeReviewedSameTrack.nonEmpty) {
                             @if(nextToBeReviewedSameTrack.head.track.id == proposal.track.id) {
                                 <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
                                     @Messages("gt.nextTalkTrack" , Messages(nextToBeReviewedSameTrack.head.track.label))</a>
@@ -177,27 +177,11 @@
                                 <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
                                     @Messages("gt.nextTalk")</a>
                             }
+                        }
+                        @if(nextToBeReviewedSameFormat.nonEmpty) {
                             @if(nextToBeReviewedSameFormat.head.talkType.id == proposal.talkType.id) {
                                 <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameFormat.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
                                     @Messages("gt.nextTalkType", Messages(proposal.talkType.id))</a>
-                            } else {
-                                <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
-                                     @Messages("gt.nextTalk")</a>
-                            }
-                        }
-                        @if(nextToBeReviewedSameTrack.nonEmpty && nextToBeReviewedSameFormat.isEmpty) {
-                            @if(nextToBeReviewedSameTrack.head.track.id == proposal.track.id) {
-                                <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
-                                     @Messages("gt.nextTalkTrack" , Messages(nextToBeReviewedSameTrack.head.track.label))</a>
-                            } else {
-                                <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
-                                     @Messages("gt.nextTalk")</a>
-                            }
-                        }
-                        @if(nextToBeReviewedSameTrack.isEmpty && nextToBeReviewedSameFormat.nonEmpty) {
-                            @if(nextToBeReviewedSameFormat.head.talkType.id == proposal.talkType.id) {
-                                <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameFormat.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
-                                   @Messages("gt.nextTalkType", Messages(proposal.talkType.id))</a>
                             } else {
                                 <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
                                     @Messages("gt.nextTalk")</a>

--- a/app/views/CFPAdmin/showVotesForProposal.scala.html
+++ b/app/views/CFPAdmin/showVotesForProposal.scala.html
@@ -4,6 +4,7 @@
         totalVotesCast: Long,
         totalVotes: Long,
         allVotes: List[(String, Double)],
+        nextToBeReviewedSameTrackAndFormat: Option[Proposal],
         nextToBeReviewedSameTrack: Option[Proposal],
         nextToBeReviewedSameFormat: Option[Proposal],
         averageScoreGT: Double,
@@ -169,6 +170,10 @@
                                 @Messages("no.more.talk")</a>
                         }
                         <br>
+                        @if(nextToBeReviewedSameTrackAndFormat.nonEmpty && nextToBeReviewedSameTrackAndFormat.head.track.id == proposal.track.id) {
+                            <a class="btn btn-success" accesskey="s" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrackAndFormat.head.id)" title="Shortcut: Ctrl-Option-S"><i class="icon-forward"></i>
+                                @Messages("gt.nextTalkTrackAndType", Messages(proposal.talkType.id), Messages(proposal.track.label))</a>
+                        }
                         @if(nextToBeReviewedSameTrack.nonEmpty) {
                             @if(nextToBeReviewedSameTrack.head.track.id == proposal.track.id) {
                                 <a class="btn btn-success" accesskey="n" href="@routes.CFPAdmin.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>

--- a/app/views/GoldenTicketController/showVotesForProposal.scala.html
+++ b/app/views/GoldenTicketController/showVotesForProposal.scala.html
@@ -37,46 +37,30 @@
                     }
 
                     <p>@Messages("gt.youcan")</p>
-<a class="btn btn-warning btn-sm" accesskey="r" href="@routes.GoldenTicketController.openForReview(proposal.id)" title="Shortcut : Ctrl-Option-r"><i class="icon-backward"></i>@Messages("gt.showVotes.review")</a><br>
-<a class="btn btn-primary btn-sm" accesskey="h" href="@routes.GoldenTicketController.showAllProposals()" title="Shortcut : Ctrl-Option-h"><i class="icon-home"></i> @Messages("gt.home")</a><br>
-                @if(nextToBeReviewedSameTrack.isEmpty && nextToBeReviewedSameFormat.isEmpty){
- <a class="btn btn-primary btn-sm" href="@routes.GoldenTicketController.showAllProposals()"><i class="icon-trophy"></i> @Messages("gt.nomore")</a><br>
-                }
-                @if(nextToBeReviewedSameTrack.nonEmpty && nextToBeReviewedSameFormat.nonEmpty){
-                     @if(nextToBeReviewedSameTrack.head.track.id ==  proposal.track.id ) {
- <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
-                             @Messages("gt.nextTalkTrack", Messages(nextToBeReviewedSameTrack.head.track.label))</a><br>
-                     } else {
-                         <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
-                             @Messages("gt.nextTalk")</a><br>
-                     }
-                     @if(nextToBeReviewedSameFormat.head.talkType.id ==  proposal.talkType.id ) {
-                         <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameFormat.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
-                             @Messages("gt.nextTalkType" , Messages(proposal.talkType.id))</a><br>
-                     } else {
-                         <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
-                             @Messages("gt.nextTalk")</a><br>
-                     }
-                }
-                 @if(nextToBeReviewedSameTrack.nonEmpty && nextToBeReviewedSameFormat.isEmpty){
-                     @if(nextToBeReviewedSameTrack.head.track.id ==  proposal.track.id ) {
-                         <a class="btn btn-success" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
-                             @Messages("gt.nextTalkTrack" ,Messages(nextToBeReviewedSameTrack.head.track.label))</a><br>
-                     } else {
-                         <a class="btn btn-success" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
-                             @Messages("gt.nextTalk")</a><br>
-                     }
-                }
-                 @if(nextToBeReviewedSameTrack.isEmpty && nextToBeReviewedSameFormat.nonEmpty){
-                     @if(nextToBeReviewedSameFormat.head.talkType.id ==  proposal.talkType.id ) {
-                         <a class="btn btn-success" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameFormat.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
-                             @Messages("gt.nextTalkType", Messages(proposal.talkType.id))</a><br>
-                     } else {
-                         <a class="btn btn-success" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
-                             @Messages("gt.nextTalk")</a><br>
-                     }
-                }
+                    <a class="btn btn-warning btn-sm" accesskey="r" href="@routes.GoldenTicketController.openForReview(proposal.id)" title="Shortcut : Ctrl-Option-r"><i class="icon-backward"></i>@Messages("gt.showVotes.review")</a><br>
+                    <a class="btn btn-primary btn-sm" accesskey="h" href="@routes.GoldenTicketController.showAllProposals()" title="Shortcut : Ctrl-Option-h"><i class="icon-home"></i> @Messages("gt.home")</a><br>
+                    @if(nextToBeReviewedSameTrack.isEmpty && nextToBeReviewedSameFormat.isEmpty){
+                      <a class="btn btn-primary btn-sm" href="@routes.GoldenTicketController.showAllProposals()"><i class="icon-trophy"></i> @Messages("gt.nomore")</a><br>
+                    }
 
+                  @if(nextToBeReviewedSameTrack.nonEmpty) {
+                    @if(nextToBeReviewedSameTrack.head.track.id == proposal.track.id) {
+                      <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
+                        @Messages("gt.nextTalkTrack", Messages(nextToBeReviewedSameTrack.head.track.label))</a><br>
+                    } else {
+                      <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
+                        @Messages("gt.nextTalk")</a><br>
+                    }
+                  }
+                  @if(nextToBeReviewedSameFormat.nonEmpty) {
+                    @if(nextToBeReviewedSameFormat.head.talkType.id == proposal.talkType.id) {
+                      <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameFormat.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
+                        @Messages("gt.nextTalkType", Messages(proposal.talkType.id))</a><br>
+                    } else {
+                      <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
+                        @Messages("gt.nextTalk")</a><br>
+                    }
+                  }
                 </div>
                 <div class="col-md-12 col-lg-12">
                     <p><small>@Messages("gt.disclaimer")</small></P>

--- a/app/views/GoldenTicketController/showVotesForProposal.scala.html
+++ b/app/views/GoldenTicketController/showVotesForProposal.scala.html
@@ -1,4 +1,4 @@
-@(currentUser:String, proposal: models.Proposal, nextToBeReviewedSameTrack:Option[Proposal], nextToBeReviewedSameFormat:Option[Proposal])(implicit flash: Flash, lang: Lang, req:RequestHeader)
+@(currentUser:String, proposal: models.Proposal, nextToBeReviewedSameTrackAndFormat:Option[Proposal], nextToBeReviewedSameTrack:Option[Proposal], nextToBeReviewedSameFormat:Option[Proposal])(implicit flash: Flash, lang: Lang, req:RequestHeader)
 @main("Votes for " + proposal.id + "/" + proposal.title) {
     <div class="row">
         <div class="col-md-12">
@@ -43,6 +43,10 @@
                       <a class="btn btn-primary btn-sm" href="@routes.GoldenTicketController.showAllProposals()"><i class="icon-trophy"></i> @Messages("gt.nomore")</a><br>
                     }
 
+                  @if(nextToBeReviewedSameTrackAndFormat.nonEmpty && nextToBeReviewedSameTrackAndFormat.head.track.id == proposal.track.id) {
+                    <a class="btn btn-success btn-sm" accesskey="s" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrackAndFormat.head.id)" title="Shortcut: Ctrl-Option-S"><i class="icon-forward"></i>
+                      @Messages("gt.nextTalkTrackAndType" , Messages(proposal.talkType.id), Messages(proposal.track.label))</a>
+                  }
                   @if(nextToBeReviewedSameTrack.nonEmpty) {
                     @if(nextToBeReviewedSameTrack.head.track.id == proposal.track.id) {
                       <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>

--- a/app/views/GoldenTicketController/showVotesForProposal.scala.html
+++ b/app/views/GoldenTicketController/showVotesForProposal.scala.html
@@ -49,7 +49,7 @@
                         @Messages("gt.nextTalkTrack", Messages(nextToBeReviewedSameTrack.head.track.label))</a><br>
                     } else {
                       <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-N"><i class="icon-forward"></i>
-                        @Messages("gt.nextTalk")</a><br>
+                        @Messages("gt.nextTalkDifferentTrack", Messages(nextToBeReviewedSameTrack.head.track.label))</a><br>
                     }
                   }
                   @if(nextToBeReviewedSameFormat.nonEmpty) {
@@ -58,7 +58,7 @@
                         @Messages("gt.nextTalkType", Messages(proposal.talkType.id))</a><br>
                     } else {
                       <a class="btn btn-success btn-sm" accesskey="l" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
-                        @Messages("gt.nextTalk")</a><br>
+                        @Messages("gt.nextTalkDifferentType", Messages(nextToBeReviewedSameTrack.head.talkType.id))</a><br>
                     }
                   }
                 </div>

--- a/app/views/GoldenTicketController/showVotesForProposal.scala.html
+++ b/app/views/GoldenTicketController/showVotesForProposal.scala.html
@@ -54,10 +54,10 @@
                   }
                   @if(nextToBeReviewedSameFormat.nonEmpty) {
                     @if(nextToBeReviewedSameFormat.head.talkType.id == proposal.talkType.id) {
-                      <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameFormat.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
+                      <a class="btn btn-success btn-sm" accesskey="l" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameFormat.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
                         @Messages("gt.nextTalkType", Messages(proposal.talkType.id))</a><br>
                     } else {
-                      <a class="btn btn-success btn-sm" accesskey="n" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
+                      <a class="btn btn-success btn-sm" accesskey="l" href="@routes.GoldenTicketController.openForReview(nextToBeReviewedSameTrack.head.id)" title="Shortcut: Ctrl-Option-L"><i class="icon-forward"></i>
                         @Messages("gt.nextTalk")</a><br>
                     }
                   }

--- a/conf/messages
+++ b/conf/messages
@@ -811,11 +811,11 @@ gt.home=Go back to home
 gt.vote.ok=Your vote has been recorded.
 gt.youcan=You can now:
 gt.nomore=There is no more talk to review, congratulation you did it!
-gt.nextTalkTrackAndType=Continue and evaluate another {0} for track {1}
-gt.nextTalkType=Continue and evaluate another {0}
-gt.nextTalkDifferentType=Continue and evaluate next talk of different type : {0}
-gt.nextTalkTrack=Continue and evaluate next talk for track {0}
-gt.nextTalkDifferentTrack=Continue and evaluate next talk of different track : {0}
+gt.nextTalkTrackAndType=Continue and evaluate another [{0}] for track [{1}]
+gt.nextTalkType=Continue and evaluate another [{0}]
+gt.nextTalkDifferentType=Continue and evaluate next talk of different type : [{0}]
+gt.nextTalkTrack=Continue and evaluate next talk for track [{0}]
+gt.nextTalkDifferentTrack=Continue and evaluate next talk of different track : [{0}]
 
 gtAdmin.totalGT=Total number of person with a Golden Ticket: {0}
 gtAdmin.top5=Top 5 by score

--- a/conf/messages
+++ b/conf/messages
@@ -811,9 +811,10 @@ gt.home=Go back to home
 gt.vote.ok=Your vote has been recorded.
 gt.youcan=You can now:
 gt.nomore=There is no more talk to review, congratulation you did it!
-gt.nextTalk=Continue and evaluate next talk
 gt.nextTalkType=Continue and evaluate another {0}
+gt.nextTalkDifferentType=Continue and evaluate next talk of different type : {0}
 gt.nextTalkTrack=Continue and evaluate next talk for track {0}
+gt.nextTalkDifferentTrack=Continue and evaluate next talk of different track : {0}
 
 gtAdmin.totalGT=Total number of person with a Golden Ticket: {0}
 gtAdmin.top5=Top 5 by score

--- a/conf/messages
+++ b/conf/messages
@@ -811,6 +811,7 @@ gt.home=Go back to home
 gt.vote.ok=Your vote has been recorded.
 gt.youcan=You can now:
 gt.nomore=There is no more talk to review, congratulation you did it!
+gt.nextTalkTrackAndType=Continue and evaluate another {0} for track {1}
 gt.nextTalkType=Continue and evaluate another {0}
 gt.nextTalkDifferentType=Continue and evaluate next talk of different type : {0}
 gt.nextTalkTrack=Continue and evaluate next talk for track {0}

--- a/conf/messages.fr
+++ b/conf/messages.fr
@@ -720,6 +720,7 @@ gt.home=Retour à l''accueil
 gt.vote.ok=Votre vote a été enregistré
 gt.youcan=Vous pouvez maintenant :
 gt.nomore=Vous n''avez plus de sujets à revoir pour l''instant, revenez plus tard lorsque d''autres speakers auront proposé des sujets.
+gt.nextTalkTrackAndType=Continuer et évaluer un autre sujet du type [{0}] dans la track [{1}]
 gt.nextTalkType=Continuer et évaluer un autre sujet du type [{0}]
 gt.nextTalkDifferentType=Continuer et évaluer un autre sujet d'un type différent : {0}
 gt.nextTalkTrack=Continuer et évaluer une proposition dans la track [{0}]

--- a/conf/messages.fr
+++ b/conf/messages.fr
@@ -722,9 +722,9 @@ gt.youcan=Vous pouvez maintenant :
 gt.nomore=Vous n''avez plus de sujets à revoir pour l''instant, revenez plus tard lorsque d''autres speakers auront proposé des sujets.
 gt.nextTalkTrackAndType=Continuer et évaluer un autre sujet du type [{0}] dans la track [{1}]
 gt.nextTalkType=Continuer et évaluer un autre sujet du type [{0}]
-gt.nextTalkDifferentType=Continuer et évaluer un autre sujet d'un type différent : {0}
+gt.nextTalkDifferentType=Continuer et évaluer un autre sujet d'un type différent : [{0}]
 gt.nextTalkTrack=Continuer et évaluer une proposition dans la track [{0}]
-gt.nextTalkDifferentTrack=Continuer et évaluer un autre sujet d'une track différente : {0}
+gt.nextTalkDifferentTrack=Continuer et évaluer un autre sujet d'une track différente : [{0}]
 
 
 gtAdmin.totalGT=Nombre de personnes avec un Golden Ticket : {0}

--- a/conf/messages.fr
+++ b/conf/messages.fr
@@ -720,9 +720,11 @@ gt.home=Retour à l''accueil
 gt.vote.ok=Votre vote a été enregistré
 gt.youcan=Vous pouvez maintenant :
 gt.nomore=Vous n''avez plus de sujets à revoir pour l''instant, revenez plus tard lorsque d''autres speakers auront proposé des sujets.
-gt.nextTalk=Continuer et évaluer le sujet suivant
 gt.nextTalkType=Continuer et évaluer un autre sujet du type [{0}]
+gt.nextTalkDifferentType=Continuer et évaluer un autre sujet d'un type différent : {0}
 gt.nextTalkTrack=Continuer et évaluer une proposition dans la track [{0}]
+gt.nextTalkDifferentTrack=Continuer et évaluer un autre sujet d'une track différente : {0}
+
 
 gtAdmin.totalGT=Nombre de personnes avec un Golden Ticket : {0}
 gtAdmin.top5=Top 5 par score


### PR DESCRIPTION
Hi there :)

When I vote for talks, I like evaluating every talks by format first : for instance, starting with universities, then TiA / Quickies / BoF / HoL and ending with Conferences.

While inside a "format tunnel queue", I like processing every talks belonging to the same track.

Let's say I start evaluating an University of track Web.
Problem are : 
- When I click the "Continue and evaluate next talk for track Web, JS, HTML5 & UX", then I switch on a new Conference (because [talks are sorted by talk type in that case](https://github.com/nicmarti/cfp-devoxx/blob/dev/app/controllers/CFPAdmin.scala#L123))
- When I click the "Continue and evaluate another University", then I switch on a new "Agile, Methodology & Tests" talk type (here again, because [talks are sorted by track in that case](https://github.com/nicmarti/cfp-devoxx/blob/dev/app/controllers/CFPAdmin.scala#L124))

=> When possible, I'd like to keep the exact same format & track in my voting tunnels

_Note that I'm absolutely not against sorting talks by track/type : having sorted talks is better than keeping a random ordering. That's why I introduced a 3rd collection._

That's the purpose of this PR (as well as fixing/simplifying some code in the html template page)

Beware : I didn't took the time to setup a proper development environment (I'd miss some redis data backup) so nothing has been tested here.
=> Don't forget to test it prior to deploying to prod ;-)