### PR TITLE
Some types not concerned by quotas

### DIFF
--- a/app/controllers/Backoffice.scala
+++ b/app/controllers/Backoffice.scala
@@ -547,4 +547,26 @@ object Backoffice extends SecureCFPController {
       Ok("Result: " + result)
   }
 
+  def fixRedisDataConsistency() = SecuredAction(IsMemberOf("admin")) {
+    implicit request: SecuredRequest[play.api.mvc.AnyContent] =>
+      var summary = new StringBuilder
+
+      Proposal.allProposals().foreach(proposal => {
+        val removedStates = Proposal.ensureProposaleHasState(proposal.id, proposal.state)
+        if(removedStates != 0) {
+          summary ++= s"Removed ${removedStates} invalid states for proposal ${proposal.id} (valid state: ${proposal.state.code})\n"
+        }
+        val removedTypes = Proposal.ensureProposaleHasType(proposal.id, proposal.talkType)
+        if(removedTypes != 0) {
+          summary ++= s"Removed ${removedTypes} invalid types for proposal ${proposal.id} (valid type: ${proposal.talkType.id})\n"
+        }
+        val removeTracks = Proposal.ensureProposaleHasTrack(proposal.id, proposal.track.id)
+        if(removeTracks != 0) {
+          summary ++= s"Removed ${removeTracks} invalid tracks for proposal ${proposal.id} (valid track: ${proposal.track.id})\n"
+        }
+      })
+
+      Ok(summary.toString)
+  }
+
 }

--- a/app/controllers/CallForPaper.scala
+++ b/app/controllers/CallForPaper.scala
@@ -378,10 +378,11 @@ object CallForPaper extends SecureCFPController {
     implicit request =>
       val uuid = request.webuser.uuid
       val maybeProposal = Proposal.findDraft(uuid, proposalId)
-      val currentSubmitted: Int = Proposal.countSubmittedAccepted(uuid)
+      val currentlySubmittedConcernedByQuota: Int = Proposal.countSubmittedAcceptedConcernedByQuota(uuid)
+      val additionnalConcernedByQuota: Int = if (maybeProposal.map(p => ConferenceDescriptor.ConferenceProposalConfigurations.isConcernedByCountRestriction(p.talkType)).getOrElse(false)) 1 else 0
 
       maybeProposal match {
-        case _ if currentSubmitted >= ConferenceDescriptor.maxProposals() =>
+        case _ if currentlySubmittedConcernedByQuota + additionnalConcernedByQuota > ConferenceDescriptor.maxProposals() =>
           Redirect(routes.CallForPaper.homeForSpeaker()).flashing("error" -> Messages("cfp.maxProposals.reached", ConferenceDescriptor.maxProposals()))
         case Some(proposal) =>
           Proposal.submit(uuid, proposalId)

--- a/app/controllers/CallForPaper.scala
+++ b/app/controllers/CallForPaper.scala
@@ -383,7 +383,11 @@ object CallForPaper extends SecureCFPController {
 
       maybeProposal match {
         case _ if currentlySubmittedConcernedByQuota + additionnalConcernedByQuota > ConferenceDescriptor.maxProposals() =>
-          Redirect(routes.CallForPaper.homeForSpeaker()).flashing("error" -> Messages("cfp.maxProposals.reached", ConferenceDescriptor.maxProposals()))
+          Redirect(routes.CallForPaper.homeForSpeaker()).flashing(
+            "error" -> Messages("cfp.maxProposals.reached",
+                ConferenceDescriptor.maxProposals(),
+                ConferenceDescriptor.ConferenceProposalConfigurations.concernedByCountQuotaRestrictionAndNotHidden.map(pc => Messages(ProposalType.byProposalConfig(pc).simpleLabel)).mkString(", ")
+            ))
         case Some(proposal) =>
           Proposal.submit(uuid, proposalId)
           if (ConferenceDescriptor.notifyProposalSubmitted) {

--- a/app/library/Zedis.scala
+++ b/app/library/Zedis.scala
@@ -160,6 +160,13 @@ trait Dress {
       j.sinter(setA, setB).asScala.toSet
     }
 
+    def sinter(setA: String, setB: String, setC: String): Set[String] = {
+      if (play.Logger.of("library.Zedis").isDebugEnabled) {
+        play.Logger.of("library.Zedis").debug(s"sinter $setA $setB $setC")
+      }
+      j.sinter(setA, setB, setC).asScala.toSet
+    }
+
     def srandmember(key: String): Option[String] = {
       if (play.Logger.of("library.Zedis").isDebugEnabled) {
         play.Logger.of("library.Zedis").debug(s"srandmember $key")

--- a/app/models/ConferenceDescriptor.scala
+++ b/app/models/ConferenceDescriptor.scala
@@ -54,12 +54,13 @@ case class ProposalConfiguration(id: String, slotsCount: Int,
                                  hiddenInCombo: Boolean = false,
                                  chosablePreferredDay: Boolean = false,
                                  impliedSelectedTrack: Option[Track] = None,
+                                 concernedByCountQuotaRestriction: Boolean = true,
                                  allowOtherSpeaker: Boolean = true)
 
 object ProposalConfiguration {
 
   val UNKNOWN = ProposalConfiguration(id = "unknown", slotsCount = 0, givesSpeakerFreeEntrance = false, freeEntranceDisplayed = false,
-    htmlClass = "", hiddenInCombo = true, chosablePreferredDay = false)
+    concernedByCountQuotaRestriction = false, htmlClass = "", hiddenInCombo = true, chosablePreferredDay = false)
 
   def parse(propConf: String): ProposalConfiguration = {
     ConferenceDescriptor.ConferenceProposalConfigurations.ALL.find(p => p.id == propConf).getOrElse(ProposalConfiguration.UNKNOWN)
@@ -153,7 +154,7 @@ object ConferenceDescriptor {
     val CONF = ProposalConfiguration(id = "conf", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.CONF.id)), givesSpeakerFreeEntrance = true, freeEntranceDisplayed = true, htmlClass = "fas fa-bullhorn",
       chosablePreferredDay = true)
     val UNI = ProposalConfiguration(id = "uni", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.UNI.id)), givesSpeakerFreeEntrance = true, freeEntranceDisplayed = true, htmlClass = "fas fa-laptop",
-      chosablePreferredDay = false)
+      concernedByCountQuotaRestriction = false, chosablePreferredDay = false)
     val TIA = ProposalConfiguration(id = "tia", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.TIA.id)), givesSpeakerFreeEntrance = true, freeEntranceDisplayed = true, htmlClass = "fas fa-tools",
       chosablePreferredDay = true)
     val LAB = ProposalConfiguration(id = "lab", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.LAB.id)), givesSpeakerFreeEntrance = true, freeEntranceDisplayed = true, htmlClass = "fas fa-flask",
@@ -161,14 +162,20 @@ object ConferenceDescriptor {
     val QUICK = ProposalConfiguration(id = "quick", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.QUICK.id)), givesSpeakerFreeEntrance = true, freeEntranceDisplayed = true, htmlClass = "fas fa-fast-forward",
       chosablePreferredDay = true, allowOtherSpeaker = false)
     val BOF = ProposalConfiguration(id = "bof", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.BOF.id)), givesSpeakerFreeEntrance = false, freeEntranceDisplayed = false, htmlClass = "fas fa-users",
-      chosablePreferredDay = false)
+      concernedByCountQuotaRestriction = false, chosablePreferredDay = false)
     val KEY = ProposalConfiguration(id = "key", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.KEY.id)), givesSpeakerFreeEntrance = true, freeEntranceDisplayed = false, htmlClass = "fas fa-microphone",
-      chosablePreferredDay = true)
+      concernedByCountQuotaRestriction = false, chosablePreferredDay = true)
     val OTHER = ProposalConfiguration(id = "other", slotsCount = 1, givesSpeakerFreeEntrance = false, freeEntranceDisplayed = false, htmlClass = "fas fa-microphone-alt",
       hiddenInCombo = true, chosablePreferredDay = false)
 
     val ALL = List(CONF, UNI, TIA, LAB, QUICK, BOF, KEY, OTHER)
 
+    def concernedByCountQuotaRestriction: List[ProposalConfiguration] = {
+      ALL.filter(_.concernedByCountQuotaRestriction)
+    }
+    def isConcernedByCountRestriction(proposalType: ProposalType): Boolean = {
+      ALL.filter(_.id == proposalType.id).exists(_.concernedByCountQuotaRestriction)
+    }
     def doesItGivesSpeakerFreeEntrance(proposalType: ProposalType): Boolean = {
       ALL.filter(_.id == proposalType.id).exists(_.givesSpeakerFreeEntrance)
     }

--- a/app/models/ConferenceDescriptor.scala
+++ b/app/models/ConferenceDescriptor.scala
@@ -173,6 +173,9 @@ object ConferenceDescriptor {
     def concernedByCountQuotaRestriction: List[ProposalConfiguration] = {
       ALL.filter(_.concernedByCountQuotaRestriction)
     }
+    def concernedByCountQuotaRestrictionAndNotHidden: List[ProposalConfiguration] = {
+      ALL.filter(p => p.concernedByCountQuotaRestriction && !p.hiddenInCombo)
+    }
     def isConcernedByCountRestriction(proposalType: ProposalType): Boolean = {
       ALL.filter(_.id == proposalType.id).exists(_.concernedByCountQuotaRestriction)
     }

--- a/app/models/Proposal.scala
+++ b/app/models/Proposal.scala
@@ -38,6 +38,10 @@ object ProposalType {
     finalFormat
   }
 
+  def byProposalConfig(pc: ProposalConfiguration): ProposalType = {
+    all.find(_.id == pc.id).get
+  }
+
   def allIDsOnly = allAsId.map(_._1)
 
 

--- a/app/models/Proposal.scala
+++ b/app/models/Proposal.scala
@@ -402,7 +402,7 @@ object Proposal {
 
   private def changeProposalType(uuid: String, proposalId: String, newProposalType: ProposalType) = Redis.pool.withClient {
     client =>
-      val maybeExistingType = for (t <- ProposalState.allAsCode if client.sismember("Proposals:ByType:" + t, proposalId)) yield t
+      val maybeExistingType = for (t <- ProposalType.allAsId.map(_._1) if client.sismember("Proposals:ByType:" + t, proposalId)) yield t
 
       // Do the operation on the ProposalState
       maybeExistingType.filterNot(_ == newProposalType.id).foreach {

--- a/app/models/Proposal.scala
+++ b/app/models/Proposal.scala
@@ -456,6 +456,25 @@ object Proposal {
       }
   }
 
+  def ensureProposaleHasState(proposalId: String, expectedProposalState: ProposalState): Long = Redis.pool.withClient {
+    implicit client =>
+      ProposalState.allAsCode.filter(_ != expectedProposalState.code).map(unexpectedStateCode =>
+        client.srem(s"Proposals:ByState:${unexpectedStateCode}", proposalId)
+      ).sum
+  }
+  def ensureProposaleHasType(proposalId: String, expectedProposalType: ProposalType): Long = Redis.pool.withClient {
+    implicit client =>
+      ConferenceDescriptor.ConferenceProposalTypes.ALL.filter(_.id != expectedProposalType.id).map(unexpectedType =>
+        client.srem(s"Proposals:ByType:${unexpectedType.id}", proposalId)
+      ).sum
+  }
+  def ensureProposaleHasTrack(proposalId: String, expectedProposalTrackId: String): Long = Redis.pool.withClient {
+    implicit client =>
+      Track.allIDs.filter(_ != expectedProposalTrackId).map(unexpectedTrackId =>
+        client.srem(s"Proposals:ByTrack:${unexpectedTrackId}", proposalId)
+      ).sum
+  }
+
   def getSubmissionDate(proposalId: String): Option[Long] = Redis.pool.withClient {
     implicit client =>
       client.hget("Proposal:SubmittedDate", proposalId).map {

--- a/app/views/CallForPaper/homeForSpeaker.scala.html
+++ b/app/views/CallForPaper/homeForSpeaker.scala.html
@@ -85,7 +85,7 @@
                 </div>
 
                 <div class="alert alert-info">
-                  @Messages("proposal.limit", ConferenceDescriptor.maxProposals())
+                  @Messages("proposal.limit", ConferenceDescriptor.maxProposals(), ConferenceDescriptor.ConferenceProposalConfigurations.concernedByCountQuotaRestrictionAndNotHidden.map(pc => Messages(ProposalType.byProposalConfig(pc).simpleLabel)).mkString(", "))
                 </div>
             } else {
                 <div class="panel panel-success">

--- a/conf/messages
+++ b/conf/messages
@@ -264,7 +264,7 @@ table.pres.action=Actions
 table.pres.doSubmit=Submit
 table.pres.doDelete=Delete
 
-proposal.limit=The limit is {0} maximum allowed proposals per speaker.
+proposal.limit=As a speaker you can propose a maximum of {0} proposals amongst types: {1}
 proposal.draft.reminder=Do not forget to submit your talk
 
 total.draft={0} proposals
@@ -946,7 +946,7 @@ invalid.phone.txt=Invalid phone number or permission to send an SMS has not been
 
 admin.btn.devoxxians=All Devoxxians
 
-cfp.maxProposals.reached=Warning, you cannot submit more than {0} proposals. We had to limit the number of submission.
+cfp.maxProposals.reached=Your proposal wasn''t submitted. As a speaker you can propose a maximum of {0} proposals amongst types: {1}
 cfp.member=CFP Member
 
 golden.welcome.txt=Welcome to the Golden Ticket private section. Buy a Golden Ticket on {0} web site, and get access to proposals! Be part of the team that review and select talks for {0}.

--- a/conf/messages.fr
+++ b/conf/messages.fr
@@ -243,7 +243,7 @@ table.pres.action=Actions
 table.pres.doSubmit=Soumettre
 table.pres.doDelete=Effacer
 
-proposal.limit=La limite est de {0} sujets proposés par speaker.
+proposal.limit=En tant que speaker, vous pouvez proposer un maximum de {0} propositions parmi les types: {1}
 proposal.draft.reminder=N''oubliez pas de soumettre ce sujet
  
 total.draft={0} propositions
@@ -825,7 +825,7 @@ invalid.phone.txt=Votre numéro de téléphone n''est pas valide ou n''est pas a
 
 admin.btn.devoxxians=Tous les Devoxxians
 
-cfp.maxProposals.reached=Attention, vous ne pouvez pas soumettre plus de {0} sujets. Nous limitons le nombre de soumissions volontairement.
+cfp.maxProposals.reached=Votre proposition n''a pas été soumise. En tant que speaker, vous pouvez proposer un maximum de {0} propositions parmi les types: {1}
 videoLinkMessage=Lien vers une vidéo
 videoLinkMessage.help=Vous pouvez partager un lien vers une vidéo où vous avez été orateur ou une vidéo en rapport avec votre proposition de sujet. Indiquez l''URL complète YouTube ou autre.
 videoLink=Vidéo relative à votre proposition

--- a/conf/routes
+++ b/conf/routes
@@ -374,6 +374,7 @@ GET           /assets/*file                                                     
 
 # TODO NMA
 GET           /admin/checkInvalidWebuserForAllSpeakers                          controllers.Backoffice.checkInvalidWebuserForAllSpeakers()
+GET           /admin/fixRedisDataConsistency                                     controllers.Backoffice.fixRedisDataConsistency()
 
 # SMS
 GET           /sms/speakers                                                     controllers.SMSController.allSpeakers()


### PR DESCRIPTION
New PR aimed at *not* considering BoF / UNI / KEYNOTE / UNKNOWN talks in the max proposal quota

Because we're missing BoF / UNI talks.

Note that I fixed a bug (introduced early 2018) which was leading to data inconsistencies in the `Proposals:ByType:*` collection during a proposal `Type` change.
For example, when a speaker was changing a Proposal from `conf` to `tia`, the `Proposals:ByType:conf` was never removed.
Not sure what the implications were, but I guess that it wasn't a good thing for various checks.

I didn't provided the Redis migration script, meaning that inconsistencies that have already happened because of proposal type changes will still be there in the db.
Problem to this latest point is : now that proposal type is going to be taken into consideration in quota check, a proposal submission that was passing yesterday will not pass tomorrow for speakers who :
- Have submitted 3 proposals
- AND have changed a proposal type in the past
_(that's an example)_

Ideally, it would be nice to fix such inconsistencies prior to merging this PR

PS: I'll rebase current PR over #194 once it will be merged, because there are some conflicts between 2 PRs