### PR TITLE
Improving voting stats3

### DIFF
--- a/app/assets/css/cfp.less
+++ b/app/assets/css/cfp.less
@@ -648,67 +648,67 @@ progress:after {
   right: 0;
 }
 
-.btn-color-0 {
+.btn-color-0, .score[data-score='0'] .displayed-score {
   color: #fff;
   background-color: @lightgrey;
   border-color: @lightgrey;
 }
 
-.btn-color-1{
-  color: #fff;
+.btn-color-1, .score .minus, .score[data-score='1'] .displayed-score {
+ color: #fff;
  background-color: #e4151c;
  border-color: #e2061a;
 }
 
-.btn-color-2{
+.btn-color-2, .score[data-score='2'] .displayed-score {
   color: #fff;
  background-color: #ed4b24;
  border-color: #e93120;
 }
 
-.btn-color-3{
+.btn-color-3, .score[data-score='3'] .displayed-score {
  color: #fff;
  background-color: #ed882c;
  border-color: #ed6d29;
 }
 
-.btn-color-4{
+.btn-color-4, .score[data-score='4'] .displayed-score {
  color: #fff;
  background-color: #edc034;
  border-color: #eda931;
 }
 
-.btn-color-5{
+.btn-color-5, .score[data-score='5'] .displayed-score {
  color: #fff;
  background-color: #ede038;
  border-color: #edd637;
 }
 
-.btn-color-6{
+.btn-color-6, .score[data-score='6'] .displayed-score {
  color: #fff;
  background-color: #d0df36;
  border-color: #e1e237;
 }
 
-.btn-color-7{
+.btn-color-7, .score[data-score='7'] .displayed-score {
  color: #fff;
  background-color: #9cc630;
  border-color: #b4d333;
 }
 
-.btn-color-8{
+.btn-color-8, .score .plus, .score[data-score='8'] .displayed-score {
  color: #fff;
  background-color: #7cb22c;
  border-color: #63a229;
 }
 
-.btn-color-9{
+.btn-color-9, .score[data-score='9'] .displayed-score {
  color: #fff;
  background-color: #428b24;
  border-color: #2b7c21;
 }
 
-.btn-color-10{
+.btn-color-10, .score[data-score='10'] .displayed-score {
  color: #fff;
  background-color: #116a1d;
  border-color: #2b7c21;
@@ -720,6 +720,15 @@ progress:after {
   border-color:#000;
   border-style: solid;
   border-width: 2px;
+}
+
+.score {
+  &[data-score='0'] {
+    .minus, .displayed-score .regular-score { display: none; }
+  }
+  &:not([data-score='0']) .displayed-score .abs-score { display: none; }
+  &[data-score='10'] .plus { display: none; }
+  &[data-score-updated='false'] .refresh { display: none; }
 }
 
 .speakerOverview{

--- a/app/views/CFPAdmin/allMyVotes.scala.html
+++ b/app/views/CFPAdmin/allMyVotes.scala.html
@@ -12,12 +12,14 @@
                 <div class="col-md-12">
                     <h3><i class="fas fa-flask"></i> Your personnal leaderboard</h3>
                     <div style="margin: 3px 0px">
+                    <i class="fas fa-filter"></i> @Messages("ar.proposalType") :
                     @models.ConferenceDescriptor.ConferenceProposalTypes.ALL.map{confType=>
                         <a href="@routes.CFPAdmin.allMyVotes(confType.id, selectedTrack)" class="btn btn-sm @if(confType.id==talkType) { btn-success } else { btn-primary }">@Messages(confType.id)</a>
                     }
                     </div>
                     <br/>
                     <div style="margin: 3px 0px">
+                        <i class="fas fa-filter"></i> @Messages("cfp.filter.on") :
                         <a href="@routes.CFPAdmin.allMyVotes(talkType, None)" class="btn btn-sm @if(selectedTrack==None) { btn-success } else { btn-primary }">All tracks</a>
                         @models.ConferenceDescriptor.ConferenceTracks.ALL.map{track =>
                             <a href="@routes.CFPAdmin.allMyVotes(talkType, Some(track.id))" class="btn btn-sm @if(selectedTrack==Some(track.id)) { btn-success } else { btn-primary }">@Messages(track.label)</a>

--- a/app/views/CFPAdmin/allMyVotes.scala.html
+++ b/app/views/CFPAdmin/allMyVotes.scala.html
@@ -58,9 +58,9 @@
                                         <tr>
                                             <td class="score" data-score="@score" data-pid="@proposalId">
                                             <div class="btn-group-xs">
+                                                    <button data-score="@Math.max(0,score-1)" data-id="@proposalId" class="btn minus btn-xs btn-color-1">-</button>
                                                     <button class="btn btn-xs btn-color-@score">@if(score==0){ @Messages("Abs") } else { @score }</button>
                                                     <button data-score="@Math.min(10,score+1)" data-id="@proposalId" class="btn plus btn-xs btn-color-8">+</button>
-                                                    <button data-score="@Math.max(0,score-1)" data-id="@proposalId" class="btn minus btn-xs btn-color-1">-</button>
                                             </div>
                                         </td>
 

--- a/app/views/CFPAdmin/allMyVotes.scala.html
+++ b/app/views/CFPAdmin/allMyVotes.scala.html
@@ -56,13 +56,14 @@
                                 @allMyVotes.map { case (proposalId, vote) =>
                                     @defining(Math.round(vote)) { score =>
                                         <tr>
-                                            <td class="score" data-score="@score" data-pid="@proposalId">
-                                            <div class="btn-group-xs">
-                                                    <button data-score="@Math.max(0,score-1)" data-id="@proposalId" class="btn minus btn-xs btn-color-1">-</button>
-                                                    <button class="btn btn-xs btn-color-@score">@if(score==0){ @Messages("Abs") } else { @score }</button>
-                                                    <button data-score="@Math.min(10,score+1)" data-id="@proposalId" class="btn plus btn-xs btn-color-8">+</button>
-                                            </div>
-                                        </td>
+                                            <td class="score" data-score-updated="false" data-initial-score="@score" data-score="@score" data-pid="@proposalId">
+                                                <div class="btn-group-xs">
+                                                    <button class="btn minus btn-xs" style="width: 34px">-</button>
+                                                    <button class="btn btn-xs displayed-score"><span class="abs-score">@Messages("Abs")</span><span class="regular-score">@score</span></button>
+                                                    <button class="btn plus btn-xs" style="width: 34px">+</button>
+                                                    <a href="@routes.CFPAdmin.allMyVotes(talkType, selectedTrack)" class="btn btn-xs btn-primary refresh"><i class="fas fa-sync"></i></a>
+                                                </div>
+                                            </td>
 
                                          <td>@allScoresForProposals.get(proposalId)</td>
                                     <td><a href="@routes.CFPAdmin.openForReview(proposalId)" class="btn btn-sm btn-primary">@proposalId</a></td>
@@ -93,40 +94,28 @@
 
 <script type="text/javascript">
 $( document ).ready(function() {
-    function generateCell(newScore, pid){
-        return '<td style="width: 82px" class="score" data-score="' + newScore + '" data-pid="' + pid +
-                '">' +
-        '<div class="btn-group btn-group-xs">' +
-                '<button class="btn btn-xs btn-color-' + newScore +
-                '">' + newScore +
-                '</button>' +
-                '<a href="@routes.CFPAdmin.allMyVotes(talkType)" class="btn btn-xs btn-primary"><i class="fas fa-sync"></i></a>' +
-                '</div></td>';
-
-    }
-
-    function handleVote(){
-        $('#tableMyVotes').find('.btn.plus, .btn.minus').on('click', function(event) {
+    function handleVote(selector, updateVoteCallback){
+        $('#tableMyVotes').find(selector).on('click', function(event) {
             var $btnClicked = $(event.currentTarget);
             var $cell = $btnClicked.parents('td');
-            var $row = $cell.parents('tr');
-            $row.addClass('myVotesRowUpdated');
 
-            var newScore = Number($btnClicked.attr('data-score'));
-            var proposalId = $btnClicked.attr('data-id');
+            var newScore = updateVoteCallback(Number($cell.attr('data-score')));
+            var proposalId = $cell.attr('data-pid');
 
             $.ajax({
                 url: '/cfpadmin/proposal/'+proposalId+'/vote?vote='+newScore,
                 cache: false
             }).then(function(){
+                $cell.find('.regular-score').text(newScore);
+                $cell.attr('data-score', newScore);
+                $cell.attr('data-score-updated', ''+newScore !== $cell.attr('data-initial-score'));
                 console.log('Vote '+proposalId+' set to '+newScore);
-                $row.find('td').eq(0).after(generateCell(newScore, proposalId));
-                $cell.remove();
             });
         });
     }
 
-    handleVote();
+    handleVote('.btn.plus', function(score) { return score+1; });
+    handleVote('.btn.minus', function(score) { return score-1; });
 });
 </script>
 

--- a/app/views/GoldenTicketController/allMyGoldenTicketVotes.scala.html
+++ b/app/views/GoldenTicketController/allMyGoldenTicketVotes.scala.html
@@ -56,13 +56,14 @@
 
                                 @allMyVotes.map { case (proposalId, vote) =>
                                      @defining(Math.round(vote)){ score =>
-                                <tr>
-                                        <td class="score" data-score="@score" data-pid="@proposalId">
-                                            <Div class="btn-group btn-group-xs">
-                                                    <button data-score="@Math.max(0,score-1)" data-id="@proposalId" class="btn minus btn-xs btn-color-1" style="margin-left:3px; margin-right: 3px;">-</button>
-                                                    <button class="btn btn-xs btn-color-@score">@if(score==0){ @Messages("Abs") } else { @score }</button>
-                                                    <button data-score="@Math.min(10,score+1)" data-id="@proposalId" class="btn plus btn-xs btn-color-8" style="margin-left:3px; margin-right: 3px;">+</button>
-                                                </Div>
+                                    <tr>
+                                        <td class="score" data-score-updated="false" data-initial-score="@score" data-score="@score" data-pid="@proposalId">
+                                            <div class="btn-group btn-group-xs">
+                                                <button class="btn minus btn-xs" style="margin-left:3px; margin-right: 3px; width: 34px">-</button>
+                                                <button class="btn btn-xs displayed-score"><span class="abs-score">@Messages("Abs")</span><span class="regular-score">@score</span></button>
+                                                <button class="btn plus btn-xs" style="margin-left:3px; margin-right: 3px; width: 34px;">+</button>
+                                                <a href="@routes.GoldenTicketController.allMyGoldenTicketVotes(talkType, selectedTrack)" class="btn btn-xs btn-primary refresh"><i class="fas fa-sync"></i></a>
+                                            </div>
                                         </td>
 
                                     <td><a href="@routes.GoldenTicketController.openForReview(proposalId)" class="btn btn-sm btn-primary">@proposalId</a></td>
@@ -92,44 +93,30 @@
 </div>
 
 <script type="text/javascript">
-
 $( document ).ready(function() {
-    function generateCell(newScore, pid){
-        return '<td style="width: 82px" class="score" data-score="' + newScore + '" data-pid="' + pid +
-                '">' +
-        '<div class="btn-group btn-group-xs">' +
-                '<button class="btn btn-xs btn-color-' + newScore +
-                '">' + newScore +
-                '</button>' +
-                '<a href="@routes.GoldenTicketController.allMyGoldenTicketVotes(talkType)" class="btn btn-xs btn-primary"><i class="fas fa-sync"></i></a>' +
-                '</div></td>';
-
-    }
-
-    function handleVote(){
-        $('#tableMyVotes').find('.btn.plus, .btn.minus').on('click', function(event) {
+    function handleVote(selector, updateVoteCallback){
+        $('#tableMyVotes').find(selector).on('click', function(event) {
             var $btnClicked = $(event.currentTarget);
             var $cell = $btnClicked.parents('td');
-            var $row = $cell.parents('tr');
-            $row.addClass('myVotesRowUpdated');
 
-            var newScore = Number($btnClicked.attr('data-score'));
-            var proposalId = $btnClicked.attr('data-id');
+            var newScore = updateVoteCallback(Number($cell.attr('data-score')));
+            var proposalId = $cell.attr('data-pid');
 
             $.ajax({
                 url: '/cfp/goldenticket/proposals/'+proposalId+'/vote?vote='+newScore,
                 cache: false
             }).then(function(){
+                $cell.find('.regular-score').text(newScore);
+                $cell.attr('data-score', newScore);
+                $cell.attr('data-score-updated', ''+newScore !== $cell.attr('data-initial-score'));
                 console.log('Vote '+proposalId+' set to '+newScore);
-                $row.find('td').eq(0).after(generateCell(newScore, proposalId));
-                $cell.remove();
             });
         });
     }
 
-    handleVote();
+    handleVote('.btn.plus', function(score) { return score+1; });
+    handleVote('.btn.minus', function(score) { return score-1; });
 });
-
 </script>
 
 }

--- a/app/views/GoldenTicketController/allMyGoldenTicketVotes.scala.html
+++ b/app/views/GoldenTicketController/allMyGoldenTicketVotes.scala.html
@@ -59,9 +59,9 @@
                                 <tr>
                                         <td class="score" data-score="@score" data-pid="@proposalId">
                                             <Div class="btn-group btn-group-xs">
+                                                    <button data-score="@Math.max(0,score-1)" data-id="@proposalId" class="btn minus btn-xs btn-color-1" style="margin-left:3px; margin-right: 3px;">-</button>
                                                     <button class="btn btn-xs btn-color-@score">@if(score==0){ @Messages("Abs") } else { @score }</button>
                                                     <button data-score="@Math.min(10,score+1)" data-id="@proposalId" class="btn plus btn-xs btn-color-8" style="margin-left:3px; margin-right: 3px;">+</button>
-                                                    <button data-score="@Math.max(0,score-1)" data-id="@proposalId" class="btn minus btn-xs btn-color-1" style="margin-left:3px; margin-right: 3px;">-</button>
                                                 </Div>
                                         </td>
 

--- a/app/views/GoldenTicketController/allMyGoldenTicketVotes.scala.html
+++ b/app/views/GoldenTicketController/allMyGoldenTicketVotes.scala.html
@@ -14,12 +14,14 @@
                 <div class="col-md-12">
                     <h3><i class="fas fa-flask"></i> @Messages("gt.personnal")</h3>
                     <div style="3px 0px">
+                    <i class="fas fa-filter"></i> @Messages("ar.proposalType") :
                     @models.ConferenceDescriptor.ConferenceProposalTypes.ALL.filter(models.ConferenceDescriptor.ConferenceProposalConfigurations.accessibleTypeToGoldenTicketReviews(_)).map{confType=>
                         <a href="@routes.GoldenTicketController.allMyGoldenTicketVotes(confType.id, selectedTrack)" class="btn btn-sm @if(confType.id==talkType) { btn-success } else { btn-primary }">@Messages(confType.id)</a>
                     }
                     </div>
                     <br/>
                     <div style="3px 0px">
+                        <i class="fas fa-filter"></i> @Messages("cfp.filter.on") :
                         <a href="@routes.GoldenTicketController.allMyGoldenTicketVotes(talkType, None)" class="btn btn-sm @if(selectedTrack==None) { btn-success } else { btn-primary }">All tracks</a>
                         @models.ConferenceDescriptor.ConferenceTracks.ALL.map{track =>
                             <a href="@routes.GoldenTicketController.allMyGoldenTicketVotes(talkType, Some(track.id))" class="btn btn-sm @if(selectedTrack==Some(track.id)) { btn-success } else { btn-primary }">@Messages(track.label)</a>


### PR DESCRIPTION
Follow up for #203

I didn't fully implemented what I said in #203 because my assumptions were not totally right : I assumed scores were updated only when clicking the "refresh" button...
It wasn't the case : score is updated as soon as +/- buttons are clicked ... and the refresh button is *really* a refresh button (it is used to refresh current page, useful particularly in order to refresh scores sorting)
=> It means that a "global refresh" button was pointless

In the end, I made following changes :
- +/-/refresh buttons are now displayed (or not) based on CSS selectors : no need to generate some HTML anymore ("-" is not displayed when score=abs, "+" is not displayed when score=10)
- When score is changed one time, we can still change it again (previously, +/- buttons were removed from the DOM)
- Changed order of buttons from `[score] [refresh] [+] [-]` to `[-] [score] [refresh] [+]`
- I kept the behaviour to not "realtime sort" scores everytime we change one of them : if you want to sort again the whole table, simply click on 1 of the refreshes buttons

![improvements-on-stats3](https://user-images.githubusercontent.com/603815/72193328-32367080-3409-11ea-9359-a655ca3345f9.gif)
