### PR TITLE
main schedule table caption should not be visible

### DIFF
--- a/app/views/Publisher/homePublisher.scala.html
+++ b/app/views/Publisher/homePublisher.scala.html
@@ -19,7 +19,7 @@
         <section class="bg-white pb-1">
             <div class="container mx-auto">
                 <table class="w-full table-fixed mainSchedule">
-                    <caption>Programme par jour et format de présentation</caption>
+                    <caption class="hidden">Programme par jour et format de présentation</caption>
                     <thead>
                         <tr>
                             <th class="w-1/3 scheduleHeader" scope="col">


### PR DESCRIPTION
That's a regression introduced just before the merge of PR #245 

<img width="1228" alt="Schedule_-_Devoxx_France_2021" src="https://user-images.githubusercontent.com/603815/131853472-af9b844e-585c-443b-a58b-c0aa1c60a04a.png">
