### PR TITLE
When schedule is published, but rooms aren't, time slot are not displayed

### DIFF
--- a/app/views/Publisher/showProposal.scala.html
+++ b/app/views/Publisher/showProposal.scala.html
@@ -32,7 +32,7 @@
                     <p class="text-left"><span class="text-bold text-xl">Niveau de la présentation :</span> @Messages(proposal.audienceLevel + ".label")</p>
 
                 @if(slot.isDefined) {
-                    @if(maybeProgramSchedule.exists(_.showRooms) && maybeProgramSchedule.exists(_.showSchedule)) {
+                    @if(maybeProgramSchedule.exists(_.showSchedule)) {
                         @if(maybeProgramSchedule.exists(_.showRooms)) {
                             <p class="text-left"><span class="text-bold text-xl">Salle :</span> @slot.map(_.room.name)
                         }


### PR DESCRIPTION
After a discussion with @aheritier, it appears that the rule to show time slot on publisher's talk detail page is not well implemented.

Currently, time slot are displayed only when schedule is published AND rooms are shown.

The second part of the rule is useless in our case : there is no problem displaying a talk time slot (which is displayed already on the schedule page anyway) on the talk detail page.

This PR fixes this.