### PR TITLE
[fix] Searching a speaker by url (name) must find the one with an accepted session

### DIFF
--- a/app/controllers/Publisher.scala
+++ b/app/controllers/Publisher.scala
@@ -68,7 +68,7 @@ object Publisher extends Controller {
   def showSpeakerByName(name: String) = Action {
     implicit request =>
 
-      val speakers = Speaker.allSpeakersWithAcceptedTerms()
+      val speakers = Speaker.withOneProposal(Speaker.allSpeakersWithAcceptedTerms())
       val speakerNameAndUUID = speakers.map {
         speaker => (speaker.urlName, speaker.uuid)
       }.toMap

--- a/app/models/Proposal.scala
+++ b/app/models/Proposal.scala
@@ -1024,12 +1024,12 @@ object Proposal {
 
   def hasOneAcceptedProposal(speakerUUID: String): Boolean = Redis.pool.withClient {
     implicit client =>
-      client.sunion(s"Proposals:ByAuthor:$speakerUUID", s"Proposals:ByState:${ProposalState.ACCEPTED.code}").nonEmpty
+      client.sinter(s"Proposals:ByAuthor:$speakerUUID", s"Proposals:ByState:${ProposalState.ACCEPTED.code}").nonEmpty
   }
 
   def hasOneRejectedProposal(speakerUUID: String): Boolean = Redis.pool.withClient {
     implicit client =>
-      client.sunion(s"Proposals:ByAuthor:$speakerUUID", s"Proposals:ByState:${ProposalState.REJECTED.code}").nonEmpty
+      client.sinter(s"Proposals:ByAuthor:$speakerUUID", s"Proposals:ByState:${ProposalState.REJECTED.code}").nonEmpty
   }
 
   def hasOnlyRejectedProposals(speakerUUID: String): Boolean = Redis.pool.withClient {


### PR DESCRIPTION
@nicmarti cc @fcamblor 

Otherwise we take the first profile we find if a given speaker has several ones

+ fix Proposal#hasOneAcceptedProposal and Proposal#hasOneRejectedProposal which should use intersections and not unions