### PR TITLE
[chore] [UX] Make more visible the links to daily agenda pages

### DIFF
--- a/app/views/Publisher/devoxxFR.scala.html
+++ b/app/views/Publisher/devoxxFR.scala.html
@@ -19,6 +19,7 @@
                 background: linear-gradient(90deg, #06858c 0%, #54b587 100%);
             }
     </style>
+    <link href="@routes.Assets.at(path="/public",file="fontawesome-5.12.0/css/all.min.css")" rel="stylesheet">
 </head>
 <body class="leading-normal tracking-normal gradient" style="font-family: 'Source Sans Pro', sans-serif;">
     <!--Nav-->

--- a/app/views/Publisher/homePublisher.scala.html
+++ b/app/views/Publisher/homePublisher.scala.html
@@ -24,21 +24,18 @@
                     <thead>
                         <tr>
                             <th class="w-1/3 scheduleHeader" scope="col">
-                                @Messages("day-wednesday")
                                 <a href="@routes.Publisher.showByDay("wed", None, includeTypes = None, excludeTypes = Some(ConferenceProposalTypes.BOF.id))">
-                                [Détails]
+                                <span class="text-xl underline">@Messages("day-wednesday")</span>&nbsp;<i class="far fa-calendar-alt"></i>
                                 </a>
                             </th>
                             <th class="w-1/3 scheduleHeader" scope="col">
-                                @Messages("day-thursday")
                                 <a href="@routes.Publisher.showByDay("thu", None, includeTypes = None, excludeTypes = Some(ConferenceProposalTypes.BOF.id))">
-                                [Détails]
+                                <span class="text-xl underline">@Messages("day-thursday")</span>&nbsp;<i class="far fa-calendar-alt"></i>
                                 </a>
                             </th>
                             <th class="w-1/3 scheduleHeader" scope="col">
-                                @Messages("day-friday")
                                 <a href="@routes.Publisher.showByDay("fri", None, includeTypes = None, excludeTypes = Some(ConferenceProposalTypes.BOF.id))">
-                                [Détails]
+                                <span class="text-xl underline">@Messages("day-friday")</span>&nbsp;<i class="far fa-calendar-alt"></i>
                                 </a>
                             </th>
                         </tr>


### PR DESCRIPTION
I got a lot of feedbacks that it's hard to find on our website the links to daily agenda pages.
It's mainly because they are accessible from "Details" text with no underline
<img width="1237" alt="Screenshot 2021-09-27 at 11 59 27" src="https://user-images.githubusercontent.com/174600/134888195-0dea552f-5780-4344-90fb-66fda4f34b0a.png">

I highlighted them like this:
<img width="1205" alt="Screenshot 2021-09-27 at 12 00 10" src="https://user-images.githubusercontent.com/174600/134888217-5f3238aa-2649-4e18-928a-6f72c2e1aeb4.png">

WDYT @nicmarti @fcamblor ?

