### PR TITLE
Helping review after resetted votes

### DIFF
--- a/app/controllers/CFPAdmin.scala
+++ b/app/controllers/CFPAdmin.scala
@@ -4,7 +4,7 @@ import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchResponse}
 import library.search.ElasticSearch
 import library.{SendMessageInternal, SendMessageToSpeaker, _}
 import models.Review._
-import models._
+import models.{Review, _}
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTimeZone
 import play.api.data.Forms._
@@ -88,9 +88,10 @@ object CFPAdmin extends SecureCFPController {
           val speakerDiscussion = Comment.allSpeakerComments(proposal.id)
           val internalDiscussion = Comment.allInternalComments(proposal.id)
           val maybeMyVote = Review.lastVoteByUserForOneProposal(uuid, proposalId)
+          val maybeMyPreviousVote = if(maybeMyVote.isEmpty) Review.previouslyResettedVote(uuid, proposalId) else None
           val proposalsByAuths = allProposalByProposal(proposal)
           val userWatchPref = ProposalUserWatchPreference.proposalUserWatchPreference(proposalId, uuid)
-          Ok(views.html.CFPAdmin.showProposal(proposal, proposalsByAuths, speakerDiscussion, internalDiscussion, messageForm, messageForm, voteForm, maybeMyVote, uuid, userWatchPref))
+          Ok(views.html.CFPAdmin.showProposal(proposal, proposalsByAuths, speakerDiscussion, internalDiscussion, messageForm, messageForm, voteForm, maybeMyVote, maybeMyPreviousVote, uuid, userWatchPref))
         case None => NotFound("Proposal not found").as("text/html")
       }
   }
@@ -186,9 +187,10 @@ object CFPAdmin extends SecureCFPController {
               val speakerDiscussion = Comment.allSpeakerComments(proposal.id)
               val internalDiscussion = Comment.allInternalComments(proposal.id)
               val maybeMyVote = Review.lastVoteByUserForOneProposal(uuid, proposalId)
+              val maybeMyPreviousVote = if(maybeMyVote.isEmpty) Review.previouslyResettedVote(uuid, proposalId) else None
               val proposals = allProposalByProposal(proposal)
               val userWatchPref = ProposalUserWatchPreference.proposalUserWatchPreference(proposalId, uuid)
-              BadRequest(views.html.CFPAdmin.showProposal(proposal, proposals, speakerDiscussion, internalDiscussion, hasErrors, messageForm, voteForm, maybeMyVote, uuid, userWatchPref))
+              BadRequest(views.html.CFPAdmin.showProposal(proposal, proposals, speakerDiscussion, internalDiscussion, hasErrors, messageForm, voteForm, maybeMyVote, maybeMyPreviousVote, uuid, userWatchPref))
             },
             validMsg => {
               Comment.saveCommentForSpeaker(proposal.id, uuid, validMsg) // Save here so that it appears immediatly
@@ -211,9 +213,10 @@ object CFPAdmin extends SecureCFPController {
               val speakerDiscussion = Comment.allSpeakerComments(proposal.id)
               val internalDiscussion = Comment.allInternalComments(proposal.id)
               val maybeMyVote = Review.lastVoteByUserForOneProposal(uuid, proposalId)
+              val maybeMyPreviousVote = if(maybeMyVote.isEmpty) Review.previouslyResettedVote(uuid, proposalId) else None
               val proposals = allProposalByProposal(proposal)
               val userWatchPref = ProposalUserWatchPreference.proposalUserWatchPreference(proposalId, uuid)
-              BadRequest(views.html.CFPAdmin.showProposal(proposal, proposals, speakerDiscussion, internalDiscussion, messageForm, hasErrors, voteForm, maybeMyVote, uuid, userWatchPref))
+              BadRequest(views.html.CFPAdmin.showProposal(proposal, proposals, speakerDiscussion, internalDiscussion, messageForm, hasErrors, voteForm, maybeMyVote, maybeMyPreviousVote, uuid, userWatchPref))
             },
             validMsg => {
               Comment.saveInternalComment(proposal.id, uuid, validMsg) // Save here so that it appears immediatly
@@ -255,9 +258,10 @@ object CFPAdmin extends SecureCFPController {
               val speakerDiscussion = Comment.allSpeakerComments(proposal.id)
               val internalDiscussion = Comment.allInternalComments(proposal.id)
               val maybeMyVote = Review.lastVoteByUserForOneProposal(uuid, proposalId)
+              val maybeMyPreviousVote = if(maybeMyVote.isEmpty) Review.previouslyResettedVote(uuid, proposalId) else None
               val proposals = allProposalByProposal(proposal)
               val userWatchPref = ProposalUserWatchPreference.proposalUserWatchPreference(proposalId, uuid)
-              BadRequest(views.html.CFPAdmin.showProposal(proposal, proposals, speakerDiscussion, internalDiscussion, messageForm, messageForm, hasErrors, maybeMyVote, uuid, userWatchPref))
+              BadRequest(views.html.CFPAdmin.showProposal(proposal, proposals, speakerDiscussion, internalDiscussion, messageForm, messageForm, hasErrors, maybeMyVote, maybeMyPreviousVote, uuid, userWatchPref))
             },
             validVote => {
               Review.voteForProposal(proposalId, uuid, validVote)

--- a/app/models/Event.scala
+++ b/app/models/Event.scala
@@ -312,6 +312,7 @@ case class GTVoteForProposalEvent(creator: String, proposalId: String, vote: Int
 case class VoteForProposalEvent(creator: String, proposalId: String, vote: Int)
   extends ProposalEvent {
   def message(): String = Messages("events.VoteForProposal", vote, proposalId)
+  def toReview(): Review = Review(creator, proposalId, vote, date)
 }
 
 case class RemovedProposalVoteEvent(creator: String, proposalId: String)

--- a/app/models/Notifications.scala
+++ b/app/models/Notifications.scala
@@ -94,6 +94,13 @@ object NotificationEvent {
       classOf[ReplacedProposalSecondarySpeakerEvent]
     )
   )
+  val PROPOSAL_COMITEE_VOTES_RESETTED = NotificationEvent(
+    id="PROPOSAL_COMITEE_VOTES_RESETTED", labelI18nKey="email.notifications.events.once.comitee.votes.resetted",
+    applicableTo = user => Webuser.isMember(user.uuid, "cfp"),
+    applicableEventTypes = List(
+      classOf[AllProposalVotesResettedEvent]
+    )
+  )
   val PROPOSAL_FINAL_APPROVAL_SUBMITTED = NotificationEvent(
     id="PROPOSAL_FINAL_APPROVAL_SUBMITTED", labelI18nKey="email.notifications.events.once.proposal.final.approval.provided",
     applicableTo = user => Webuser.isMember(user.uuid, "cfp"),
@@ -106,7 +113,8 @@ object NotificationEvent {
     ONCE_PROPOSAL_SUBMITTED, PROPOSAL_CONTENT_UPDATED, PROPOSAL_RESUBMITTED,
     DEPRECATED_PROPOSAL_PUBLIC_COMMENT_SUBMITTED,
     PROPOSAL_PUBLIC_COMMENT_SUBMITTED, PROPOSAL_INTERNAL_COMMENT_SUBMITTED,
-    PROPOSAL_SPEAKERS_LIST_ALTERED, PROPOSAL_FINAL_APPROVAL_SUBMITTED
+    PROPOSAL_SPEAKERS_LIST_ALTERED, PROPOSAL_COMITEE_VOTES_RESETTED,
+    PROPOSAL_FINAL_APPROVAL_SUBMITTED
   )
 
   def valueOf(id: String) = {

--- a/app/views/CFPAdmin/showProposal.scala.html
+++ b/app/views/CFPAdmin/showProposal.scala.html
@@ -1,4 +1,4 @@
-@(proposal: Proposal, proposalsByAuths: Map[String, Map[String, Proposal]], speakerComments: List[Comment], internalComments: List[Comment], msgToSpeakerForm: Form[String], msgInternalForm: Form[String], voteForm: Form[Int], maybeMyVote: Option[Review], currentUser: String, userWatchPref: ProposalUserWatchPreference)(implicit flash: Flash, lang: Lang, req: RequestHeader)
+@(proposal: Proposal, proposalsByAuths: Map[String, Map[String, Proposal]], speakerComments: List[Comment], internalComments: List[Comment], msgToSpeakerForm: Form[String], msgInternalForm: Form[String], voteForm: Form[Int], maybeMyVote: Option[Review], maybeMyPreviousVote: Option[Review], currentUser: String, userWatchPref: ProposalUserWatchPreference)(implicit flash: Flash, lang: Lang, req: RequestHeader)
 
 @main("[CFP] " + proposal.id + "/" + proposal.title) {
     <div class="row">
@@ -218,6 +218,11 @@
                                 }
                             }
                             </div><!-- btn block -->
+                            @maybeMyPreviousVote.map { previousReview =>
+                                <em>
+                                    @Html(Messages("admin.sp.previous.vote.after.votes.reset", tags.renderVote(previousReview.vote.toInt), previousReview.date.toString("EEEE d MMM YYYY HH:mm")))
+                                </em>
+                            }
                         }
                     </div><!-- card body -->
                     @if(flash.get("vote").isDefined) {

--- a/app/views/Mails/digest/sendDigest.scala.html
+++ b/app/views/Mails/digest/sendDigest.scala.html
@@ -50,6 +50,15 @@
             </ul>
         }
 
+        @userDigest.concernedByEvents_html(NotificationEvent.PROPOSAL_COMITEE_VOTES_RESETTED) { events =>
+            <h3>Resetted votes</h3>
+            <ul>
+                @userDigest.distinctProposalsOf(events) { case (proposal, link, proposalEvents) =>
+                <li><a href="@{link.href}">@{proposal.id} - @{proposal.title}</a></li>
+                }
+            </ul>
+        }
+
         @userDigest.concernedByEvents_html(NotificationEvent.PROPOSAL_FINAL_APPROVAL_SUBMITTED) { events =>
             <h3>Approved talks</h3>
             <ul>

--- a/app/views/Mails/digest/sendDigest.scala.txt
+++ b/app/views/Mails/digest/sendDigest.scala.txt
@@ -37,11 +37,18 @@ DevoxxFR Email Digest (@userDigest.digest.value)
   }}
 }
 
+@userDigest.concernedByEvents_txt(NotificationEvent.PROPOSAL_COMITEE_VOTES_RESETTED) { events =>
+  [[Resetted votes]]
+  @userDigest.distinctProposalsOf(events) { case (proposal, link, proposalEvents) =>
+    - @{proposal.id} - @{proposal.title} (@{link.href})
+  }
+}
+
 @userDigest.concernedByEvents_txt(NotificationEvent.PROPOSAL_FINAL_APPROVAL_SUBMITTED) { events =>
   [[Approved talks]]
-    @userDigest.distinctProposalsOf(events) { case (proposal, link, proposalEvents) =>
-      - @{proposal.id} - @{proposal.title} (@{link.href})
-    }
+  @userDigest.distinctProposalsOf(events) { case (proposal, link, proposalEvents) =>
+    - @{proposal.id} - @{proposal.title} (@{link.href})
+  }
 }
 
 Happy rating!

--- a/conf/messages
+++ b/conf/messages
@@ -401,6 +401,7 @@ admin.sp.committee_speaker=Between Committee & Speaker
 admin.btn.sendMessage=Post your message
 admin.sp.internal=Private discussions
 admin.sp.deleteMyVote=Delete my vote
+admin.sp.previous.vote.after.votes.reset=Prior to <u>vote reset</u>, you voted <strong>{0}</strong> on {1}
 admin.btn.allvotes=All votes
 admin.proposals.watch=Watch
 admin.proposals.watch.suggestion=Click here to enable watch on following proposal events

--- a/conf/messages
+++ b/conf/messages
@@ -60,6 +60,7 @@ email.notifications.events.once.public.comment.submitted=Public comment
 email.notifications.events.once.internal.comment.submitted=Internal comment
 email.notifications.events.once.proposal.speakers.altered=Speaker added / removed
 email.notifications.events.once.proposal.final.approval.provided=Proposal accepted/refused by admins
+email.notifications.events.once.comitee.votes.resetted=All votes resetted on proposal
 
 email.digest.description=Receive new proposals notifications via a digest email.
 email.digest.realtime.description=Interval is every 5 minutes.

--- a/conf/messages.fr
+++ b/conf/messages.fr
@@ -879,6 +879,7 @@ email.notifications.events.once.public.comment.submitted=Commentaire public
 email.notifications.events.once.internal.comment.submitted=Commentaire privé
 email.notifications.events.once.proposal.speakers.altered=Rajout / Suppression d''un speaker
 email.notifications.events.once.proposal.final.approval.provided=Acceptation / Refus de la proposition par les admins
+email.notifications.events.once.comitee.votes.resetted=Tous les votes ont été réinitialisés sur la proposition
 
 email.digest.description=En tant que membre du CFP, vous pouvez demander à recevoir ici automatiquement un résumé des soumissions postées chaque jour, par les autres orateurs. Cette fonction n''est accessible que parce que votre profil appartient au groupe "CFP".
 email.digest.realtime.description=Pseudo temps réel (délai max de 5min)

--- a/conf/messages.fr
+++ b/conf/messages.fr
@@ -348,6 +348,7 @@ admin.sp.committee_speaker=Entre le speaker et le comité
 admin.btn.sendMessage=Envoyer votre message
 admin.sp.internal=Discussions internes et privées
 admin.sp.deleteMyVote=Annuler mon vote
+admin.sp.previous.vote.after.votes.reset=Avant <u>la réinitialisation des votes</u>, vous aviez voté <strong>{0}</strong> le {1}
 admin.btn.allvotes=Tous les votes
 admin.proposals.watch=Observer
 admin.proposals.watch.suggestion=Cliquer ici pour activer l''observation sur les évènements de la proposition


### PR DESCRIPTION
This PR aims at helping reviewer retrieve their previous vote when a Vote resetted event happens.

These changes are two fold : 

- Digest section to votes resetted is added (with dedicated event to track it)
<img width="694" alt="CFP_Admin_-_Email_Digests_Queue_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/144156601-a2e6feeb-68d6-404c-a345-64902786ad67.png">
<img width="864" alt="CFP_Admin_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/144156700-ce61e941-7f3b-4c3c-a5ac-12b907b282bb.png">

- Previous vote is shown under votes : 
<img width="729" alt="_CFP__GMZ-4258_qweqeqweq_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/144157049-ae9164bf-f303-436c-bed2-56d17fb579c7.png">

_This is only shown if a vote was casted prior to any reset, and no new vote has been casted since latest reset_
