### PR TITLE
No comitee email on pub comment

### DIFF
--- a/app/notifiers/Mails.scala
+++ b/app/notifiers/Mails.scala
@@ -77,20 +77,6 @@ object Mails {
     )
     val newMessageId = MailerPlugin.send(email) // returns the message-ID
 
-    // For Program committee
-    // The URL to the talk is different, thus we need another template.
-    val emailForCommittee = Email(
-      subject = s"[${proposal.id}] Message to a speaker - ${proposal.title}",
-      from = fromSender,
-      to = Seq(committeeEmail),
-      bcc = bccEmail.map(s => List(s)).getOrElse(Seq.empty[String]),
-      bodyText = Some(views.txt.Mails.sendMessageToSpeakerCommittee(fromWebuser.cleanName, toWebuser.cleanName, proposal, msg).toString()),
-      bodyHtml = Some(views.html.Mails.sendMessageToSpeakerCommitte(fromWebuser.cleanName, toWebuser.cleanName, proposal, msg).toString()),
-      charset = Some("utf-8"),
-      headers = inReplyHeaders
-    )
-    MailerPlugin.send(emailForCommittee)
-
     newMessageId
   }
 

--- a/conf/routes
+++ b/conf/routes
@@ -368,6 +368,7 @@ GET           /assets/*file                                                     
 # TODO NMA
 GET           /admin/checkInvalidWebuserForAllSpeakers                          controllers.Backoffice.checkInvalidWebuserForAllSpeakers()
 GET           /admin/fixRedisDataConsistency                                    controllers.Backoffice.fixRedisDataConsistency()
+GET           /admin/fixUnsentSpeakerEmailsAfterPublicComment                    controllers.Backoffice.fixUnsentSpeakerEmailsAfterPublicComment()
 
 GET           /bp/fullAgenda                                                    controllers.Backoffice.exportAgenda()
 


### PR DESCRIPTION
This PR fixes a regression introduced during #259 : no emails are sent to speakers when a public comment is posted by comitee.

A special admin-only endpoint has been set-up to recover (re-send) these emails : 
1/ Navigate to https://cfp.devoxx.fr/admin/fixUnsentSpeakerEmailsAfterPublicComment?start=2021-11-01T00:00:00Z&end=2021-12-01T08:00:00Z&sendEmail=false and check that every emails are looking good

<img width="1087" alt="localhost_9000_admin_fixUnsentSpeakerEmailsAfterPublicComment_start_2021-11-01T00_00_00Z_end_2021-12-01T12_00_00Z_sendEmail_false" src="https://user-images.githubusercontent.com/603815/144249140-3cd8148c-23b1-4125-b6da-dd5585a5d241.png">

2/ If everything is good, simply change `sendEmail=false` to `sendEmail=true` to send the email to speakers.

