### PR TITLE
[feature] Restore proposals cloudTag

### DIFF
--- a/app/models/Tags.scala
+++ b/app/models/Tags.scala
@@ -44,7 +44,7 @@ object Tags {
 
       })
 
-      termCounts.toList
+      termCounts.toList.sortBy(- _.count)
   }
 
   def allProposals(): List[TagProposalEntry] = Redis.pool.withClient {

--- a/app/views/Backoffice/homeBackoffice.scala.html
+++ b/app/views/Backoffice/homeBackoffice.scala.html
@@ -73,6 +73,7 @@
             <a href="@routes.Backoffice.newTag()" class="btn btn-sm btn-primary"><i class="fas fa-plus"></i> New tag</a>
             <a href="@routes.Backoffice.getProposalsByTags()" class="btn btn-sm btn-primary"><i class="fas fa-tags"></i> All proposals by Tags</a>
             <a href="@routes.Backoffice.getSelectionByTags()" class="btn btn-sm btn-primary"><i class="fas fa-tags"></i> Review Selection by Tags</a>
+            <a href="@routes.Backoffice.getCloudTag()" class="btn btn-sm btn-primary"><i class="fas fa-cloud"></i> Cloud Tag</a>
             <a href="@routes.Backoffice.importTags()" class="btn btn-sm btn-primary"><i class="fas fa-truck"></i> Import tags</a>
             <a href="@routes.Backoffice.exportTags()" class="btn btn-sm btn-primary"><i class="fas fa-save"></i> Export tags</a>
 

--- a/app/views/CallForPaper/cloudTags.scala.html
+++ b/app/views/CallForPaper/cloudTags.scala.html
@@ -27,7 +27,7 @@
       .padding(5)
       .rotate(function() { return ~~(Math.random() * 2) * 90; })
       .font("Impact")
-      .fontSize(function(d) { return d.size*0.8; })
+      .fontSize(function(d) { return d.size*0.3; })
       .on("end", draw)
       .start();
 

--- a/conf/routes
+++ b/conf/routes
@@ -177,6 +177,7 @@ POST          /admin/tags/saveAll                                               
 DELETE        /admin/tag/delete/:uuid                                           controllers.Backoffice.deleteTag(uuid : String)
 GET           /admin/tags                                                       controllers.Backoffice.getProposalsByTags()
 GET           /admin/tags/selection                                             controllers.Backoffice.getSelectionByTags()
+GET           /admin/cloudTag                                                   controllers.Backoffice.getCloudTag()
 
 # Favorites and starred talks
 GET           /admin/favorites                                                  controllers.Favorites.showAllForAdmin()


### PR DESCRIPTION
It was removed in #237 by error cc @nicmarti 

Unlike the CallForPaper#cloudTags which is using ES, BackOffice#getCloudTag uses Redis

Minor update: classify the list of tags by decreasing count

<img width="608" alt="Screenshot 2021-12-28 at 15 17 14" src="https://user-images.githubusercontent.com/174600/147575495-0f3c4dd6-33bb-481c-a572-2a818482cc1f.png">

