### PR TITLE
[fix] Use the gravatar url when a specific url is not defined

### DIFF
--- a/app/views/Publisher/committee.scala.html
+++ b/app/views/Publisher/committee.scala.html
@@ -24,7 +24,9 @@
                         <a href="@routes.Publisher.showSpeaker(speaker.uuid, speaker.urlName)"
                         class="flex flex-wrap no-underline hover:no-underline">
                             @speaker.avatarUrl.map { url =>
-                                <img src="@url" class="w-32 h-32 p-4 bg-gray-200" alt="@speaker.cleanName" title="@speaker.cleanName">
+                                <img src="@url" class="w-32 p-4 bg-gray-200" alt="@speaker.cleanName" title="@speaker.cleanName">
+                            }.getOrElse {
+                                <img src="//www.gravatar.com/avatar/@Webuser.gravatarHash(speaker.email)?s=128" class="w-32 p-4 bg-gray-200" alt="@speaker.cleanName" title="@speaker.cleanName"/>
                             }
                             <p class="mt-2 text-sm text-gray-800 block">@speaker.cleanName</p>
                         </a>

--- a/app/views/Publisher/showAllSpeakers.scala.html
+++ b/app/views/Publisher/showAllSpeakers.scala.html
@@ -32,6 +32,8 @@
                             class="flex flex-wrap no-underline hover:no-underline">
                                 @speaker.avatarUrl.map { url =>
                                     <img src="@url" class="w-full p-4 bg-gray-200 h-full" alt="@speaker.cleanName" title="@speaker.cleanName">
+                                }.getOrElse {
+                                    <img src="//www.gravatar.com/avatar/@Webuser.gravatarHash(speaker.email)?s=256" class="w-full p-4 bg-gray-200 h-full" alt="@speaker.cleanName" title="@speaker.cleanName"/>
                                 }
                             <span class="mt-2 text-sm text-gray-800 block">@speaker.cleanName</span>
                             </a>

--- a/app/views/Publisher/showProposal.scala.html
+++ b/app/views/Publisher/showProposal.scala.html
@@ -68,7 +68,11 @@
 
                 <div class="px-2 py-4 sm:bg-gray-300 md:bg-white lg:bg-white">
                 @proposal.allSpeakers.map { speaker =>
-                    <img src="@speaker.avatarUrl" class="w-21 h-32" alt="@speaker.cleanName" title="@speaker.cleanName">
+                    @speaker.avatarUrl.map { url =>
+                        <img src="@url" class="w-21" alt="@speaker.cleanName" title="@speaker.cleanName">
+                    }.getOrElse {
+                        <img src="//www.gravatar.com/avatar/@Webuser.gravatarHash(speaker.email)?s=128" class="w-21" alt="@speaker.cleanName" title="@speaker.cleanName"/>
+                    }
 
                     <a href="@routes.Publisher.showSpeakerByName(speaker.urlName)" class="text-bold hover:underline hover:text-yellow-600">
                         <span class="text-yellow-600 text-bold">&gt;&nbsp;</span> @speaker.cleanName</a>

--- a/app/views/Publisher/showSpeaker.scala.html
+++ b/app/views/Publisher/showSpeaker.scala.html
@@ -10,7 +10,9 @@
             <Div class="flex flex-wrap space-x-2">
                 <div class="flex-shrink-0 w-1/5 sm:w-full md:w-2/5 ">
                 @speaker.avatarUrl.map{url=>
-                    <img class="rounded w-15 l-16"  src="@url"  alt="@speaker.cleanName" title="@speaker.cleanName">
+                    <img src="@url" class="rounded w-15" alt="@speaker.cleanName" title="@speaker.cleanName">
+                }.getOrElse {
+                    <img src="//www.gravatar.com/avatar/@Webuser.gravatarHash(speaker.email)?s=128" class="rounded w-15" alt="@speaker.cleanName" title="@speaker.cleanName"/>
                 }
                 </div>
                 <div class="flex-1 w-4/5 sm:w-full md:w-3/5">


### PR DESCRIPTION
(lost in the migration to tailwind)

Also force only the image width and not the height.
Gravatar images are cropped and in square form but for images defined by speakers they can have any ratio.