### PR TITLE
Deliberation quick fixes

### DIFF
--- a/app/controllers/ApproveOrRefuse.scala
+++ b/app/controllers/ApproveOrRefuse.scala
@@ -45,9 +45,9 @@ object ApproveOrRefuse extends SecureCFPController {
         proposal =>
           ApprovedProposal.approve(proposal)
           Event.storeEvent(ApprovedProposalEvent(request.webuser.uuid, proposalId, proposal.title, proposal.talkType.id, proposal.track.id))
-          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id, None)).flashing("success" -> s"Talk ${proposal.id} has been accepted."))
+          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id)).flashing("success" -> s"Talk ${proposal.id} has been accepted."))
       }.getOrElse {
-        Future.successful(Redirect(routes.CFPAdmin.allVotes("all", None)).flashing("error" -> "Talk not found"))
+        Future.successful(Redirect(routes.CFPAdmin.allVotes()).flashing("error" -> "Talk not found"))
       }
   }
 
@@ -57,9 +57,9 @@ object ApproveOrRefuse extends SecureCFPController {
         proposal =>
           ApprovedProposal.refuse(proposal)
           Event.storeEvent(TalkRefusedEvent(request.webuser.uuid, proposalId, proposal.title, proposal.talkType.id, proposal.track.id))
-          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id, None)).flashing("success" -> s"Talk ${proposal.id} has been refused."))
+          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id)).flashing("success" -> s"Talk ${proposal.id} has been refused."))
       }.getOrElse {
-        Future.successful(Redirect(routes.CFPAdmin.allVotes("all", None)).flashing("error" -> "Talk not found"))
+        Future.successful(Redirect(routes.CFPAdmin.allVotes()).flashing("error" -> "Talk not found"))
       }
   }
 
@@ -70,9 +70,9 @@ object ApproveOrRefuse extends SecureCFPController {
           val confType: String = proposal.talkType.id
           ApprovedProposal.cancelApprove(proposal)
           Event.storeEvent(TalkRemovedFromApprovedListEvent(request.webuser.uuid, proposalId, proposal.title, proposal.talkType.id, proposal.track.id))
-          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id, Some(confType))).flashing("success" -> s"Talk ${proposal.id} has been removed from Approved list."))
+          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id, confType)).flashing("success" -> s"Talk ${proposal.id} has been removed from Approved list."))
       }.getOrElse {
-        Future.successful(Redirect(routes.CFPAdmin.allVotes("all", None)).flashing("error" -> "Talk not found"))
+        Future.successful(Redirect(routes.CFPAdmin.allVotes()).flashing("error" -> "Talk not found"))
       }
   }
 
@@ -83,9 +83,9 @@ object ApproveOrRefuse extends SecureCFPController {
           val confType: String = proposal.talkType.id
           ApprovedProposal.cancelRefuse(proposal)
           Event.storeEvent(TalkRemovedFromRefuseListEvent(request.webuser.uuid, proposalId, proposal.title, proposal.talkType.id, proposal.track.id))
-          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id, Some(confType))).flashing("success" -> s"Talk ${proposal.id} has been removed from Refused list."))
+          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id, confType)).flashing("success" -> s"Talk ${proposal.id} has been removed from Refused list."))
       }.getOrElse {
-        Future.successful(Redirect(routes.CFPAdmin.allVotes("all", None)).flashing("error" -> "Talk not found"))
+        Future.successful(Redirect(routes.CFPAdmin.allVotes()).flashing("error" -> "Talk not found"))
       }
   }
 

--- a/app/controllers/CFPAdmin.scala
+++ b/app/controllers/CFPAdmin.scala
@@ -440,7 +440,7 @@ object CFPAdmin extends SecureCFPController {
       }
   }
 
-  def allVotes(confType: String, track: Option[String]) = SecuredAction(IsMemberOf("cfp")) {
+  def allVotes(confType: String, track: String) = SecuredAction(IsMemberOf("cfp")) {
     implicit request: SecuredRequest[play.api.mvc.AnyContent] =>
 
       play.Logger.of("application.Benchmark").debug(s"******* CFPAdmin allVotes for $confType and $track")
@@ -471,12 +471,12 @@ object CFPAdmin extends SecureCFPController {
       }, "list to display")
 
       val listToDisplay = Benchmark.measure(() => track match {
-        case None => tempListToDisplay
-        case Some(trackId) => tempListToDisplay.filter(_._1.track.id == trackId)
+        case "all" => tempListToDisplay
+        case trackId => tempListToDisplay.filter(_._1.track.id == trackId)
       }, "filter by track")
 
       val totalRemaining = Benchmark.measure(() => ApprovedProposal.remainingSlots(confType), "calculate remaining slots")
-      Ok(views.html.CFPAdmin.allVotes(listToDisplay.toList, totalApproved, totalRemaining, confType))
+      Ok(views.html.CFPAdmin.allVotes(listToDisplay.toList, totalApproved, totalRemaining, confType, track))
   }
 
   def allVotesVersion2(confType: String, page: Int = 0, resultats: Int = 25, sortBy: String = "gt_and_cfp") = SecuredAction(IsMemberOf("admin")) {

--- a/app/controllers/LeaderboardController.scala
+++ b/app/controllers/LeaderboardController.scala
@@ -151,7 +151,7 @@ object LeaderboardController extends SecureCFPController {
   def doComputeVotesTotal() = SecuredAction(IsMemberOf("cfp")) {
     implicit request: SecuredRequest[play.api.mvc.AnyContent] =>
       ZapActor.actor ! ComputeVotesAndScore()
-      Redirect(routes.CFPAdmin.allVotes("conf", None)).flashing("success" -> "Recomputing votes and scores...")
+      Redirect(routes.CFPAdmin.allVotes()).flashing("success" -> "Recomputing votes and scores...")
   }
 
   def allProposalsByCompany() = SecuredAction(IsMemberOf("cfp")) {

--- a/app/models/ConferenceDescriptor.scala
+++ b/app/models/ConferenceDescriptor.scala
@@ -203,9 +203,6 @@ object ConferenceDescriptor {
     val LANG = Track("lang", "lang.label")
     val UNKNOWN = Track("unknown", "unknown track")
     val ALL = List(JAVA, MOBILE, WEB, ARCHISEC, AGILE_DEVOPS, CLOUD, BIGDATA, FUTURE, LANG, UNKNOWN)
-
-    // Used to define pre-selected track (to avoid searching for too much proposals on "all votes" screens)
-    val DEFAULT_SEARCH_TRACK_ID = ALL.head.id
   }
 
   // TODO configure the description for each Track

--- a/app/models/ConferenceDescriptor.scala
+++ b/app/models/ConferenceDescriptor.scala
@@ -108,6 +108,9 @@ object ConferenceDescriptor {
 
     val ALL = List(CONF, UNI, TIA, LAB, QUICK, BOF, KEY, OTHER)
 
+    // Used to define pre-selected proposal type (to avoid searching for too much proposals on "all votes" screens)
+    val DEFAULT_SEARCH_PROPOSAL_ID = UNI.id
+
     def valueOf(id: String): ProposalType = id match {
       case "conf" => CONF
       case "uni" => UNI
@@ -200,6 +203,9 @@ object ConferenceDescriptor {
     val LANG = Track("lang", "lang.label")
     val UNKNOWN = Track("unknown", "unknown track")
     val ALL = List(JAVA, MOBILE, WEB, ARCHISEC, AGILE_DEVOPS, CLOUD, BIGDATA, FUTURE, LANG, UNKNOWN)
+
+    // Used to define pre-selected track (to avoid searching for too much proposals on "all votes" screens)
+    val DEFAULT_SEARCH_TRACK_ID = ALL.head.id
   }
 
   // TODO configure the description for each Track

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -1,4 +1,4 @@
-@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long)], totalApproved: Long, totalRemaining: Long, confType: String, selectedTrack: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
+@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long, Option[Double])], totalApproved: Long, totalRemaining: Long, confType: String, selectedTrack: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
     @import models.Review.{AverageNote, TotalAbst, TotalVoter}
 
     @main("All votes") {
@@ -30,6 +30,10 @@
                 </a>
             </div>
             <div class="col-md-12 mt-2">
+                <div class="form-check form-check-inline">
+                    <input type="checkbox" id="showMyVotes" onchange="showMyVotes(this.checked)" data-com.bitwarden.browser.user-edited="yes" class="form-check-input">
+                    <label class="form-check-label" for="showMyVotes">Show my votes</label>
+                </div>
                 <div class="form-check form-check-inline">
                     <input type="checkbox" id="showGTVotes" onchange="showGTVotes(this.checked)" data-com.bitwarden.browser.user-edited="yes" class="form-check-input">
                     <label class="form-check-label" for="showGTVotes">Show GT votes</label>
@@ -81,6 +85,7 @@
                             <th>Votes</th>
                             <th>Abst.</th>
                             <th class="gt-votes" style="display: none">GT & Committee</th>
+                            <th class="my-votes" style="display: none">Mine</th>
                             <th>Title</th>
                             <th>Speakers</th>
                             <th>Type</th>
@@ -90,7 +95,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                    @allVotes.map { case (proposal, voteAndTotalVotes, gtScore, gtVoteCast) =>
+                    @allVotes.map { case (proposal, voteAndTotalVotes, gtScore, gtVoteCast, maybeMyVote) =>
                         @defining(ApprovedProposal.isRefused(proposal.id, proposal.talkType.id)) { refused =>
                             @defining(ApprovedProposal.isApproved(proposal.id, proposal.talkType.id)) { approved =>
                                 <tr class="preselected_@approved refused_@refused">
@@ -115,6 +120,13 @@
                                     </td>
                                     <td class="number_table gt-votes" style="display: none">
                                     @library.Stats.average(List(gtScore, voteAndTotalVotes._4.n))
+                                    </td>
+                                    <td class="number_table my-votes" style="display: none">
+                                    @maybeMyVote.map { score =>
+                                        <span class="score" data-score="@score.intValue()">
+                                            <span class="btn displayed-score"> @score.intValue() </span>
+                                        </span>
+                                    }.getOrElse { - }
                                     </td>
                                     <td>
                                         <a href="@routes.CFPAdmin.openForReview(proposal.id)" target="@proposal.id"><small>@proposal.title
@@ -195,8 +207,8 @@
                         },
                         "aoColumnsDef": [
                             {"bSortable": "false", "bSearchable": "false", "aTargets": 0},
-                            {"sType": "numeric", "aTargets": [1, 2, 3, 4]},
-                            {"sType": "string", "aTargets": [5, 6, 7, 8, 9, 10, 11, 12,13]}
+                            {"sType": "numeric", "aTargets": [1, 3, 4, 5, 6]},
+                            {"sType": "string", "aTargets": [2, 7, 8, 9, 10, 11, 12]}
                         ],
                         "stripeClasses": []
                     });
@@ -268,6 +280,9 @@
 
                 });
 
+                function showMyVotes(show) {
+                    $(".my-votes")[show?'show':'hide']()
+                }
                 function showGTVotes(show) {
                     $(".gt-votes")[show?'show':'hide']()
                 }

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -100,6 +100,7 @@
                             <th class="prop-type-col">Type</th>
                             <th>Lang</th>
                             <th><i class="fas fa-thumbs-up"></i> / <i class="fas fa-thumbs-down"></i></th>
+                            <th class="">Summary</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -195,6 +196,9 @@
                                         <span class="badge badge-pill badge-@proposal.state.code">@proposal.state.code</span>
                                         @if(approved && (proposal.state == ProposalState.SUBMITTED || proposal.state == ProposalState.BACKUP)) {<span class="badge badge-pill badge-success"><i class="fas fa-thumbs-up"></i> pre-approved</span>}
                                         @if(refused && (proposal.state == ProposalState.SUBMITTED || proposal.state == ProposalState.BACKUP)) {<span class="badge badge-pill badge-danger"><i class="fas fa-thumbs-down"></i> pre-refused</span>}
+                                    </td>
+                                    <td class="">
+                                        @Html(proposal.summaryAsHtml)
                                     </td>
                                 </tr>
                             }
@@ -304,6 +308,7 @@
                     @if(selectedTrack=="all"){ $("#showTrack").attr('checked', true); }
 
                     ["#showProposalType", "#showTrack", "#showMyVotes", "#showGTVotes"].forEach(selector => $(selector).change());
+                    [13].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, false))
                 });
 
                 function showMyVotes(show) { [6].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -140,13 +140,17 @@
                                             </span>
                                         }
                                     </td>
-                                    <td class="number_table my-votes" style="display: none">
                                     @maybeMyVote.map { score =>
-                                        <span class="score" data-score="@score.intValue()">
-                                            <span class="btn displayed-score"> @if(score.intValue()==0){ Abs } else { @score.intValue() } </span>
-                                        </span>
-                                    }.getOrElse { - }
-                                    </td>
+                                        <td class="number_table my-votes" style="display: none" data-order="@score.intValue()">
+                                            <span class="score" data-score="@score.intValue()">
+                                                <span class="btn displayed-score"> @if(score.intValue()==0){ Abs } else { @score.intValue() } </span>
+                                            </span>
+                                        </td>
+                                    }.getOrElse {
+                                        <td class="number_table my-votes" style="display: none" data-order="-1">
+                                            -
+                                        </td>
+                                    }
                                     <td>
                                         <a href="@routes.CFPAdmin.openForReview(proposal.id)" target="@proposal.id"><small>@proposal.title
                                             @if(proposal.sponsorTalk) {
@@ -226,8 +230,8 @@
                         },
                         "aoColumnsDef": [
                             {"bSortable": "false", "bSearchable": "false", "aTargets": 0},
-                            {"sType": "numeric", "aTargets": [1, 3, 4, 5, 6]},
-                            {"sType": "string", "aTargets": [2, 7, 8, 9, 10, 11, 12]}
+                            {"sType": "numeric", "aTargets": [1, 2, 3, 4, 5, 6]},
+                            {"sType": "string", "aTargets": [7, 8, 9, 10, 11, 12]}
                         ],
                         "stripeClasses": []
                     });

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -89,15 +89,15 @@
                         <tr>
                             <th/>
                             <th>Avg</th>
-                            <th class="gt-votes" style="display: none">GT</th>
+                            <th class="gt-votes">GT</th>
                             <th>Votes</th>
                             <th>Abst.</th>
-                            <th class="gt-votes" style="display: none">GT & Committee</th>
-                            <th class="my-votes" style="display: none">Mine</th>
+                            <th class="gt-votes">GT & Committee</th>
+                            <th class="my-votes">Mine</th>
                             <th>Title</th>
                             <th>Speakers</th>
-                            <th class="prop-track-col" style="display: none">Track</th>
-                            <th class="prop-type-col" style="display: none">Type</th>
+                            <th class="prop-track-col">Track</th>
+                            <th class="prop-type-col">Type</th>
                             <th>Lang</th>
                             <th><i class="fas fa-thumbs-up"></i> / <i class="fas fa-thumbs-down"></i></th>
                         </tr>
@@ -115,7 +115,7 @@
                                         </span>
                                     }
                                     </td>
-                                    <td class="gt-votes" style="display: none">
+                                    <td class="gt-votes">
                                         <small>
                                             <span class="score" data-score="@gtScore.round">
                                                 <span class="btn-sm displayed-score">@gtScore</span>
@@ -133,7 +133,7 @@
                                         @totalAbstentions.i
                                     }
                                     </td>
-                                    <td class="number_table gt-votes" style="display: none">
+                                    <td class="number_table gt-votes">
                                         @defining(library.Stats.average(List(if(gtVoteCast>0){gtScore}else{voteAndTotalVotes._4.n}, voteAndTotalVotes._4.n))) { gtAndComiteeScore: Double =>
                                             <span class="score" data-score="@gtAndComiteeScore.round">
                                                 <span class="btn displayed-score">@gtAndComiteeScore</span>
@@ -141,13 +141,13 @@
                                         }
                                     </td>
                                     @maybeMyVote.map { score =>
-                                        <td class="number_table my-votes" style="display: none" data-order="@score.intValue()">
+                                        <td class="number_table my-votes" data-order="@score.intValue()">
                                             <span class="score" data-score="@score.intValue()">
                                                 <span class="btn displayed-score"> @if(score.intValue()==0){ Abs } else { @score.intValue() } </span>
                                             </span>
                                         </td>
                                     }.getOrElse {
-                                        <td class="number_table my-votes" style="display: none" data-order="-1">
+                                        <td class="number_table my-votes" data-order="-1">
                                             -
                                         </td>
                                     }
@@ -169,10 +169,10 @@
                                         }
                                     }
                                     </td>
-                                    <td class="prop-track-col" style="display: none">
+                                    <td class="prop-track-col">
                                         <small>@Messages(proposal.track.label)</small>
                                     </td>
-                                    <td class="prop-type-col" style="display: none">
+                                    <td class="prop-type-col">
                                         <small>@proposal.talkType.id</small>
                                     </td>
                                     <td>
@@ -300,14 +300,16 @@
                         });
                     });
 
-                    @if(confType=="all"){ $("#showProposalType").attr('checked', true); $("#showProposalType").change(); }
-                    @if(selectedTrack=="all"){ $("#showTrack").attr('checked', true); $("#showTrack").change(); }
+                    @if(confType=="all"){ $("#showProposalType").attr('checked', true); }
+                    @if(selectedTrack=="all"){ $("#showTrack").attr('checked', true); }
+
+                    ["#showProposalType", "#showTrack", "#showMyVotes", "#showGTVotes"].forEach(selector => $(selector).change());
                 });
 
-                function showMyVotes(show) { $(".my-votes")[show?'show':'hide']() }
-                function showGTVotes(show) { $(".gt-votes")[show?'show':'hide']() }
-                function showProposalType(show) { $(".prop-type-col")[show?'show':'hide']() }
-                function showTrack(show) { $(".prop-track-col")[show?'show':'hide']() }
+                function showMyVotes(show) { [6].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }
+                function showGTVotes(show) { [2,5].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }
+                function showProposalType(show) { [10].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }
+                function showTrack(show) { [9].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }
         </script>
 
     }

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -5,8 +5,8 @@
         <script type="text/javascript" charset="utf-8" language="javascript" src="//cdn.datatables.net/1.10.11/js/jquery.dataTables.min.js"></script>
         <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.11/css/jquery.dataTables.min.css">
 
-        <div class="row mt-2">
-            <div class="col-md-12">
+        <div class="row">
+            <div class="col-md-12 mt-2">
                 @for(proposalType <- ConferenceDescriptor.ConferenceProposalTypes.ALL) {
                     <a href="@routes.CFPAdmin.allVotes(proposalType.id, selectedTrack)" class="btn @if(proposalType.id == confType){ btn-success } else { btn-primary } btn-sm">
                         <i class="@ConferenceDescriptor.ConferenceProposalConfigurations.getHTMLClassFor(proposalType)"></i>
@@ -17,7 +17,8 @@
                     <i class="fas fa-adjust"></i>
                     All
                 </a>
-                <br>
+            </div>
+            <div class="col-md-12 mt-2">
                 <i class="fas fa-filter"></i> Show only:
                 @Track.all.map { track =>
                     <a href="@routes.CFPAdmin.allVotes(confType, track.id)" class="btn @if(selectedTrack == track.id){ btn-success } else { btn-primary } btn-sm">
@@ -27,13 +28,14 @@
                 <a href="@routes.CFPAdmin.allVotes(confType, "all")" class="btn @if("all" == selectedTrack){ btn-success } else { btn-primary } btn-sm">
                     All
                 </a>
-                <br>
+            </div>
+            <div class="col-md-12 mt-2">
                 <a href="@routes.LeaderboardController.doComputeVotesTotal()" class="btn btn-success btn-sm"><i class="fas fa-compass"></i>
                     Recompute total and votes</a> -
                 <a href="@routes.CFPAdmin.allApprovedSpeakersByCompany(false)" class="btn btn-danger btn-sm"><i class="fas fa-angle-double-down"></i>
                     All talks by company</a>
-                <br>
-
+            </div>
+            <div class="col-md-12">
                 @if(flash.get("error").isDefined) {
                     <div class="alert alert-danger alert-dismissable">
                         <strong>Error :</strong>
@@ -45,7 +47,8 @@
                     @flash.get("success").get
                     </div>
                 }
-                <br>
+            </div>
+            <div class="col-md-12 mt-2">
                 @defining(allVotes.count(_._1.state == ProposalState.DECLINED)) { declinedTotal =>
                     <span class="badge badge-success">@totalApproved approved</span> <span class="badge badge-declined">
                         - @declinedTotal declined</span> <span class="badge badge-warning">
@@ -56,7 +59,6 @@
                     FR</span> <span class="badge badge-secondary">@allVotes.map(_._1).count(_.lang == "en") EN</span>
 
             </div>
-
         </div>
         <div class="row">
 

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -102,11 +102,18 @@
                                     <td class="number_table"/>
                                     <td class="average_table">
                                     @defining(voteAndTotalVotes._4) { average: AverageNote =>
-                                        @average.n
+                                        <span class="score" data-score="@average.n.round">
+                                            <span class="btn displayed-score"> @average.n</span>
+                                        </span>
                                     }
                                     </td>
                                     <td class="gt-votes" style="display: none">
-                                        <small>@gtScore by @gtVoteCast <i class="fas fa-user"></i></small>
+                                        <small>
+                                            <span class="score" data-score="@gtScore.round">
+                                                <span class="btn-sm displayed-score">@gtScore</span>
+                                            </span>
+                                            by @gtVoteCast <i class="fas fa-user"></i>
+                                        </small>
                                     </td>
                                     <td class="number_table">
                                     @defining(voteAndTotalVotes._2) { totalVoters: TotalVoter =>
@@ -120,7 +127,9 @@
                                     </td>
                                     <td class="number_table gt-votes" style="display: none">
                                         @defining(library.Stats.average(List(if(gtVoteCast>0){gtScore}else{voteAndTotalVotes._4.n}, voteAndTotalVotes._4.n))) { gtAndComiteeScore: Double =>
-                                            @gtAndComiteeScore
+                                            <span class="score" data-score="@gtAndComiteeScore.round">
+                                                <span class="btn displayed-score">@gtAndComiteeScore</span>
+                                            </span>
                                         }
                                     </td>
                                     <td class="number_table my-votes" style="display: none">

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -5,19 +5,28 @@
         <script type="text/javascript" charset="utf-8" language="javascript" src="//cdn.datatables.net/1.10.11/js/jquery.dataTables.min.js"></script>
         <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.11/css/jquery.dataTables.min.css">
 
-        <div class="row">
+        <div class="row mt-2">
             <div class="col-md-12">
-                <a href="@routes.CFPAdmin.allVotes("all")" class="btn btn-primary btn-sm"><i class="fas fa-adjust"></i>
-                    All</a>
                 @for(proposalType <- ConferenceDescriptor.ConferenceProposalTypes.ALL) {
-                    <a href="@routes.CFPAdmin.allVotes(proposalType.id)" class="btn btn-primary btn-sm"><i class="@ConferenceDescriptor.ConferenceProposalConfigurations.getHTMLClassFor(proposalType)"></i> @Messages(proposalType.label + ".simple")</a>
+                    <a href="@routes.CFPAdmin.allVotes(proposalType.id, selectedTrack)" class="btn @if(proposalType.id == confType){ btn-success } else { btn-primary } btn-sm">
+                        <i class="@ConferenceDescriptor.ConferenceProposalConfigurations.getHTMLClassFor(proposalType)"></i>
+                        @Messages(proposalType.label + ".simple")
+                    </a>
                 }
+                <a href="@routes.CFPAdmin.allVotes("all", selectedTrack)" class="btn @if("all" == confType){ btn-success } else { btn-primary } btn-sm">
+                    <i class="fas fa-adjust"></i>
+                    All
+                </a>
                 <br>
                 <i class="fas fa-filter"></i> Show only:
-                @Track.allIDs.map { idTrack =>
-                    <a href="@routes.CFPAdmin.allVotes(confType, idTrack)" class="btn btn-primary btn-sm">@idTrack
-                        - @confType</a>
+                @Track.all.map { track =>
+                    <a href="@routes.CFPAdmin.allVotes(confType, track.id)" class="btn @if(selectedTrack == track.id){ btn-success } else { btn-primary } btn-sm">
+                        @Messages(track.label)
+                    </a>
                 }
+                <a href="@routes.CFPAdmin.allVotes(confType, "all")" class="btn @if("all" == selectedTrack){ btn-success } else { btn-primary } btn-sm">
+                    All
+                </a>
                 <br>
                 <a href="@routes.LeaderboardController.doComputeVotesTotal()" class="btn btn-success btn-sm"><i class="fas fa-compass"></i>
                     Recompute total and votes</a> -

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -38,6 +38,14 @@
                     <input type="checkbox" id="showGTVotes" onchange="showGTVotes(this.checked)" data-com.bitwarden.browser.user-edited="yes" class="form-check-input">
                     <label class="form-check-label" for="showGTVotes">Show GT votes</label>
                 </div>
+                <div class="form-check form-check-inline">
+                    <input type="checkbox" id="showTrack" onchange="showTrack(this.checked)" data-com.bitwarden.browser.user-edited="yes" class="form-check-input">
+                    <label class="form-check-label" for="showTrack">Show Track</label>
+                </div>
+                <div class="form-check form-check-inline">
+                    <input type="checkbox" id="showProposalType" onchange="showProposalType(this.checked)" data-com.bitwarden.browser.user-edited="yes" class="form-check-input">
+                    <label class="form-check-label" for="showProposalType">Show Proposal type</label>
+                </div>
             </div>
             <div class="col-md-12 mt-2">
                 <a href="@routes.LeaderboardController.doComputeVotesTotal()" class="btn btn-success btn-sm"><i class="fas fa-compass"></i>
@@ -88,8 +96,8 @@
                             <th class="my-votes" style="display: none">Mine</th>
                             <th>Title</th>
                             <th>Speakers</th>
-                            <th>Type</th>
-                            <th>Track</th>
+                            <th class="prop-track-col" style="display: none">Track</th>
+                            <th class="prop-type-col" style="display: none">Type</th>
                             <th>Lang</th>
                             <th><i class="fas fa-thumbs-up"></i> / <i class="fas fa-thumbs-down"></i></th>
                         </tr>
@@ -157,11 +165,11 @@
                                         }
                                     }
                                     </td>
-                                    <td>
-                                        <small>@proposal.talkType.id</small>
-                                    </td>
-                                    <td>
+                                    <td class="prop-track-col" style="display: none">
                                         <small>@Messages(proposal.track.label)</small>
+                                    </td>
+                                    <td class="prop-type-col" style="display: none">
+                                        <small>@proposal.talkType.id</small>
                                     </td>
                                     <td>
                                         [@proposal.lang]
@@ -288,15 +296,14 @@
                         });
                     });
 
-
+                    @if(confType=="all"){ $("#showProposalType").attr('checked', true); $("#showProposalType").change(); }
+                    @if(selectedTrack=="all"){ $("#showTrack").attr('checked', true); $("#showTrack").change(); }
                 });
 
-                function showMyVotes(show) {
-                    $(".my-votes")[show?'show':'hide']()
-                }
-                function showGTVotes(show) {
-                    $(".gt-votes")[show?'show':'hide']()
-                }
+                function showMyVotes(show) { $(".my-votes")[show?'show':'hide']() }
+                function showGTVotes(show) { $(".gt-votes")[show?'show':'hide']() }
+                function showProposalType(show) { $(".prop-type-col")[show?'show':'hide']() }
+                function showTrack(show) { $(".prop-track-col")[show?'show':'hide']() }
         </script>
 
     }

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -143,7 +143,7 @@
                                     <td class="number_table my-votes" style="display: none">
                                     @maybeMyVote.map { score =>
                                         <span class="score" data-score="@score.intValue()">
-                                            <span class="btn displayed-score"> @score.intValue() </span>
+                                            <span class="btn displayed-score"> @if(score.intValue()==0){ Abs } else { @score.intValue() } </span>
                                         </span>
                                     }.getOrElse { - }
                                     </td>

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -1,4 +1,4 @@
-@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long)], totalApproved: Long, totalRemaining: Long, confType: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
+@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long)], totalApproved: Long, totalRemaining: Long, confType: String, selectedTrack: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
     @import models.Review.{AverageNote, TotalAbst, TotalVoter}
 
     @main("All votes") {
@@ -7,15 +7,15 @@
 
         <div class="row">
             <div class="col-md-12">
-                <a href="@routes.CFPAdmin.allVotes("all", None)" class="btn btn-primary btn-sm"><i class="fas fa-adjust"></i>
+                <a href="@routes.CFPAdmin.allVotes("all")" class="btn btn-primary btn-sm"><i class="fas fa-adjust"></i>
                     All</a>
                 @for(proposalType <- ConferenceDescriptor.ConferenceProposalTypes.ALL) {
-                    <a href="@routes.CFPAdmin.allVotes(proposalType.id, None)" class="btn btn-primary btn-sm"><i class="@ConferenceDescriptor.ConferenceProposalConfigurations.getHTMLClassFor(proposalType)"></i> @Messages(proposalType.label + ".simple")</a>
+                    <a href="@routes.CFPAdmin.allVotes(proposalType.id)" class="btn btn-primary btn-sm"><i class="@ConferenceDescriptor.ConferenceProposalConfigurations.getHTMLClassFor(proposalType)"></i> @Messages(proposalType.label + ".simple")</a>
                 }
                 <br>
                 <i class="fas fa-filter"></i> Show only:
                 @Track.allIDs.map { idTrack =>
-                    <a href="@routes.CFPAdmin.allVotes(confType, Some(idTrack))" class="btn btn-primary btn-sm">@idTrack
+                    <a href="@routes.CFPAdmin.allVotes(confType, idTrack)" class="btn btn-primary btn-sm">@idTrack
                         - @confType</a>
                 }
                 <br>

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -119,7 +119,9 @@
                                     }
                                     </td>
                                     <td class="number_table gt-votes" style="display: none">
-                                    @library.Stats.average(List(gtScore, voteAndTotalVotes._4.n))
+                                        @defining(library.Stats.average(List(if(gtVoteCast>0){gtScore}else{voteAndTotalVotes._4.n}, voteAndTotalVotes._4.n))) { gtAndComiteeScore: Double =>
+                                            @gtAndComiteeScore
+                                        }
                                     </td>
                                     <td class="number_table my-votes" style="display: none">
                                     @maybeMyVote.map { score =>

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -30,6 +30,12 @@
                 </a>
             </div>
             <div class="col-md-12 mt-2">
+                <div class="form-check form-check-inline">
+                    <input type="checkbox" id="showGTVotes" onchange="showGTVotes(this.checked)" data-com.bitwarden.browser.user-edited="yes" class="form-check-input">
+                    <label class="form-check-label" for="showGTVotes">Show GT votes</label>
+                </div>
+            </div>
+            <div class="col-md-12 mt-2">
                 <a href="@routes.LeaderboardController.doComputeVotesTotal()" class="btn btn-success btn-sm"><i class="fas fa-compass"></i>
                     Recompute total and votes</a> -
                 <a href="@routes.CFPAdmin.allApprovedSpeakersByCompany(false)" class="btn btn-danger btn-sm"><i class="fas fa-angle-double-down"></i>
@@ -71,10 +77,10 @@
                         <tr>
                             <th/>
                             <th>Avg</th>
-                            <th>GT</th>
+                            <th class="gt-votes" style="display: none">GT</th>
                             <th>Votes</th>
                             <th>Abst.</th>
-                            <th>GT & Committee</th>
+                            <th class="gt-votes" style="display: none">GT & Committee</th>
                             <th>Title</th>
                             <th>Speakers</th>
                             <th>Type</th>
@@ -94,7 +100,7 @@
                                         @average.n
                                     }
                                     </td>
-                                    <td>
+                                    <td class="gt-votes" style="display: none">
                                         <small>@gtScore by @gtVoteCast <i class="fas fa-user"></i></small>
                                     </td>
                                     <td class="number_table">
@@ -107,7 +113,7 @@
                                         @totalAbstentions.i
                                     }
                                     </td>
-                                    <td class="number_table">
+                                    <td class="number_table gt-votes" style="display: none">
                                     @library.Stats.average(List(gtScore, voteAndTotalVotes._4.n))
                                     </td>
                                     <td>
@@ -261,6 +267,10 @@
 
 
                 });
+
+                function showGTVotes(show) {
+                    $(".gt-votes")[show?'show':'hide']()
+                }
         </script>
 
     }

--- a/app/views/CFPAdmin/cfpAdminIndex.scala.html
+++ b/app/views/CFPAdmin/cfpAdminIndex.scala.html
@@ -25,7 +25,7 @@
             <a href="@routes.CFPAdmin.allMyVotes(selectedTrack=Some(ConferenceDescriptor.ConferenceTracks.JAVA.id))" class="btn btn-sm btn-primary"><i aria-hidden="true" class="fas fa-chart-bar"></i> @Messages("admin.btn.myvotes")</a>
             <a href="@routes.CFPAdmin.showProposalsNotReviewedCompareTo(None)" class="btn btn-sm btn-primary"><i aria-hidden="true" class="fas fa-arrow-circle-right"></i> @Messages("admin.btn.otherReviewer")</a>
             <a href="@routes.CFPAdmin.allSponsorTalks()" class="btn btn-sm btn-primary"><i aria-hidden="true" class="fas fa-medal"></i> @Messages("admin.btn.sponsortalks")</a>
-            <a href="@routes.CFPAdmin.allVotes("all",None)" class="btn btn-sm btn-warning"><i aria-hidden="true" class="fas fa-adjust"></i> @Messages("admin.btn.allvotes")</a>
+            <a href="@routes.CFPAdmin.allVotes()" class="btn btn-sm btn-warning"><i aria-hidden="true" class="fas fa-adjust"></i> @Messages("admin.btn.allvotes")</a>
             <a href="@routes.InviteController.allInvitations()" class="btn btn-sm btn-primary"><i aria-hidden="true" class="fas fa-users"></i> @Messages("admin.btn.speakersInvited")</a>
             <a href="@routes.CFPAdmin.newOrEditSpeaker(None)" class="btn btn-sm btn-primary"><i aria-hidden="true" class="fas fa-umbrella"></i> @Messages("admin.btn.createNewspeaker")</a>
             @if(SecureCFPController.hasAccessToAdmin(req)){

--- a/app/views/LeaderboardController/leaderBoard.scala.html
+++ b/app/views/LeaderboardController/leaderBoard.scala.html
@@ -75,7 +75,7 @@
                             @tags.renderGravatarByProposal(mr._1)
                             <a href="@routes.CFPAdmin.showVotesForProposal(mr._1)">@mr._1</a> with @mr._2 votes
                         }
-                        <br><br><small><a href='@routes.CFPAdmin.allVotes("all", None)' class="btn btn-sm btn-primary">See all Votes</a></small>
+                        <br><br><small><a href='@routes.CFPAdmin.allVotes()' class="btn btn-sm btn-primary">See all Votes</a></small>
                     </div>
 
                         <div class="col-md-4">

--- a/conf/routes
+++ b/conf/routes
@@ -93,7 +93,7 @@ GET           /cfpadmin/proposals/byTag/:tagId                                  
 GET           /cfpadmin/myvotes                                                 controllers.CFPAdmin.allMyVotes(talkType:String ?="conf", selectedTrack:Option[String] ?=None)
 GET           /cfpadmin/myWatchedProposals                                      controllers.CFPAdmin.allMyWatchedProposals(talkType:String ?="conf", selectedTrack:Option[String] ?=None, onlyProposalHavingEvents:Boolean ?=true)
 GET           /cfpadmin/delayedReviews                                          controllers.CFPAdmin.delayedReviews()
-GET           /cfpadmin/allvotes                                                controllers.CFPAdmin.allVotes(confType:String ?=models.ConferenceDescriptor.ConferenceProposalTypes.DEFAULT_SEARCH_PROPOSAL_ID, track:String ?=models.ConferenceDescriptor.ConferenceTracks.DEFAULT_SEARCH_TRACK_ID)
+GET           /cfpadmin/allvotes                                                controllers.CFPAdmin.allVotes(confType:String ?=models.ConferenceDescriptor.ConferenceProposalTypes.DEFAULT_SEARCH_PROPOSAL_ID, track:String ?="all")
 GET           /cfpadmin/allvotesV2/:confType                                    controllers.CFPAdmin.allVotesVersion2(confType:String, page:Int ?=0, resultats:Int ?=25, sortBy:String ?="gt_and_cfp")
 
 GET           /cfpadmin/advancedsearch                                          controllers.CFPAdmin.advancedSearch(q:Option[String] ?=None,p:Option[Int] ?=None)

--- a/conf/routes
+++ b/conf/routes
@@ -93,7 +93,7 @@ GET           /cfpadmin/proposals/byTag/:tagId                                  
 GET           /cfpadmin/myvotes                                                 controllers.CFPAdmin.allMyVotes(talkType:String ?="conf", selectedTrack:Option[String] ?=None)
 GET           /cfpadmin/myWatchedProposals                                      controllers.CFPAdmin.allMyWatchedProposals(talkType:String ?="conf", selectedTrack:Option[String] ?=None, onlyProposalHavingEvents:Boolean ?=true)
 GET           /cfpadmin/delayedReviews                                          controllers.CFPAdmin.delayedReviews()
-GET           /cfpadmin/allvotes/:confType                                      controllers.CFPAdmin.allVotes(confType:String, track:Option[String])
+GET           /cfpadmin/allvotes                                                controllers.CFPAdmin.allVotes(confType:String ?=models.ConferenceDescriptor.ConferenceProposalTypes.DEFAULT_SEARCH_PROPOSAL_ID, track:String ?=models.ConferenceDescriptor.ConferenceTracks.DEFAULT_SEARCH_TRACK_ID)
 GET           /cfpadmin/allvotesV2/:confType                                    controllers.CFPAdmin.allVotesVersion2(confType:String, page:Int ?=0, resultats:Int ?=25, sortBy:String ?="gt_and_cfp")
 
 GET           /cfpadmin/advancedsearch                                          controllers.CFPAdmin.advancedSearch(q:Option[String] ?=None,p:Option[Int] ?=None)


### PR DESCRIPTION
This PR brings a bunch of enhancements for the upcoming review meetings :-)

## Showing selected conf type & track, and changing defaults to (java + uni) on allVotes screen

### Showing selected type & track, following other screens convention :
<img width="800" alt="All_votes_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/150682416-5d23799c-395f-4774-ac84-0e182a8d777f.png">

### URL change

URL is updated from `cfpadmin/allvotes/:confType?track=:track` to `cfpadmin/allvotes?confType=:confType&track=:track`
<img width="800" alt="All_votes_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/150682601-2cb1ec47-f837-4559-9ead-8fb99ab0e386.png">
<img width="800" alt="Notification_Center" src="https://user-images.githubusercontent.com/603815/150682624-6054f34e-1063-4a6d-80d8-e0a5ad8f4c9b.png">

### New buttons added to the UI to select `All` types or tracks : 
<img width="800" alt="All_votes_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/150682689-4bd3ef23-e814-445c-bb36-1905d1f7b2aa.png">

### Impacts on defaults

When not set : 
- confType is set to `uni` (before : was `all`)
- track default value is kept to `all`
=> this is done on purpose in order to decrease pressure on server "by default" when we navigate on this page


## Configuring displayed columns on allVotes screen

### New show columns checkboxes

Added some checkbox allowing to tell : 
- If we want to show GT average votes & Comitee+GT average votes - Default : **unchecked**
- If we want to show Track column - Default : **unchecked**, except if `all` track is selected
- If we want to show Proposal Type column - Default : **unchecked**, except if `all` type is selected
<img width="800" alt="All_votes_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/150682909-e8dcfb0f-c6dd-453a-b1b6-301be8b7f17a.png">

## Displaying current reviewer's vote on allVotes screen

### New column for "my votes"

Introduced a new column showing current reviewer's vote on the proposal : this can be useful to show discrepancies with comitee vote (and to allow to sort table based on your votes, without having to navigate on another screen).
This column has to be enabled (this is disabled by default so that if someone shares his screen and navigates to this page, we don't see his votes by default :-) )
<img width="800" alt="All_votes_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/150683038-de95ad6e-27fb-4eea-ac4b-5e14e2668cc6.png">

### New pre-calculated collection

To avoid too much impacts to retrieve current user's scores, I introduced a pre-calculated `Computed:ScoresForUser:<userId>` collection which is filled during scores computation job (executed every 10min)
=> Don't expect to see your votes in realtime on this screen, unless you trigger a manual recomputation.

When looking at local benchmarks, this additionnal call adds ~2ms to the execution (compared to 1-2 **seconds** for proposals loading)

## Showing colors on scores on allVotes screen

Displayed colored block around scores on : 
- Comitee average score
- GT average score
- GT+Comitee average score
- My vote
<img width="800" alt="All_votes_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/150683201-8a4309f2-0297-4f5f-8758-db18eb40673e.png">

## Search field now looks not only in title, but also insummary content

I added proposals' summary in the datatable (on an hidden column) so that it gets indexed.

This grows : 
- all-talks (780 talks) page size from 2.8MB to 4.4MB (rendered in ~8s locally vs ~7s in prod currently)
- conferences talks (475 talks) page size from 1.7Mb to 2.7Mb (rendered in ~7s locally vs ~7s in prod currently)
- 100 talks page size from 376Kb to 580Kb (rendered in ~3.5s locally vs ~3.3s in prod currently)


## Misc

Fixed a bug when GT didn't cast any vote on a proposal : we were taking their vote in the GT+Comitee average score
<img width="800" alt="All_votes_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/150683439-22800e1e-f7a9-47bd-abb5-d31fd8c72281.png">


