### PR TITLE
AllVotes screen performance improvement attempt

### DIFF
--- a/app/controllers/CFPAdmin.scala
+++ b/app/controllers/CFPAdmin.scala
@@ -467,30 +467,21 @@ object CFPAdmin extends SecureCFPController {
         () => ApprovedProposal.countApproved(confType), "count approved talks"
       )
 
-      val allProposals = Benchmark.measure(() => Proposal.loadAndParseProposals(reviews.keySet), "load and parse proposals")
+      val allMatchingProposals = Benchmark.measure(() => {
+        val allMatchingProposalIds = (confType, track) match {
+          case ("all", "all") => Proposal.allProposalIDsForTypeAndTrack(None, None, ProposalState.allButDeletedArchivedDraft)
+          case (_, "all") => Proposal.allProposalIDsForTypeAndTrack(Some(ProposalType.parse(confType)), None, ProposalState.allButDeletedArchivedDraft)
+          case ("all", _) => Proposal.allProposalIDsForTypeAndTrack(None, Some(Track.parse(track)), ProposalState.allButDeletedArchivedDraft)
+          case (_, _) => Proposal.allProposalIDsForTypeAndTrack(Some(ProposalType.parse(confType)), Some(Track.parse(track)), ProposalState.allButDeletedArchivedDraft)
+        }
+        Proposal.loadAndParseProposals(allMatchingProposalIds)
+      }, "load and parse proposals")
 
-      val listOfProposals = Benchmark.measure(() => reviews.flatMap {
-        case (proposalId, scoreAndVotes) =>
-          val maybeProposal = allProposals.get(proposalId)
-          maybeProposal match {
-            case None => play.Logger.of("CFPAdmin").error(s"Unable to load proposal id $proposalId")
-              None
-            case Some(p) =>
-              val goldenTicketScore: Double = ReviewByGoldenTicket.averageScore(p.id)
-              val gtVoteCast: Long = ReviewByGoldenTicket.totalVoteCastFor(p.id)
-              Option(p, scoreAndVotes, goldenTicketScore, gtVoteCast, allMyVotes.get(p.id))
-          }
+      val listToDisplay = Benchmark.measure(() => allMatchingProposals.values.map { proposal =>
+        val goldenTicketScore: Double = ReviewByGoldenTicket.averageScore(proposal.id)
+        val gtVoteCast: Long = ReviewByGoldenTicket.totalVoteCastFor(proposal.id)
+        (proposal, reviews.get(proposal.id), goldenTicketScore, gtVoteCast, allMyVotes.get(proposal.id))
       }, "create list of Proposals")
-
-      val tempListToDisplay = Benchmark.measure(() => confType match {
-        case "all" => listOfProposals
-        case filterType => listOfProposals.filter(_._1.talkType.id == filterType)
-      }, "list to display")
-
-      val listToDisplay = Benchmark.measure(() => track match {
-        case "all" => tempListToDisplay
-        case trackId => tempListToDisplay.filter(_._1.track.id == trackId)
-      }, "filter by track")
 
       val totalRemaining = Benchmark.measure(() => ApprovedProposal.remainingSlots(confType), "calculate remaining slots")
       Ok(views.html.CFPAdmin.allVotes(listToDisplay.toList, totalApproved, totalRemaining, confType, track))

--- a/app/library/Zedis.scala
+++ b/app/library/Zedis.scala
@@ -110,6 +110,13 @@ trait Dress {
       j.sunion(key1, key2).asScala.toSet
     }
 
+    def sunion(keys: String*): Set[String] = {
+      if (play.Logger.of("library.Zedis").isDebugEnabled) {
+        play.Logger.of("library.Zedis").debug(s"sunion ${keys.mkString(", ")}")
+      }
+      j.sunion(keys:_*).asScala.toSet
+    }
+
     def hkeys(key: String): Set[String] = {
       if (play.Logger.of("library.Zedis").isDebugEnabled) {
         play.Logger.of("library.Zedis").debug(s"hkeys $key")

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -1,4 +1,4 @@
-@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long, Option[Double])], totalApproved: Long, totalRemaining: Long, confType: String, selectedTrack: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
+@(allVotes: List[(models.Proposal, Option[(models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev)], Double, Long, Option[Double])], totalApproved: Long, totalRemaining: Long, confType: String, selectedTrack: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
     @import models.Review.{AverageNote, TotalAbst, TotalVoter}
 
     @main("All votes") {
@@ -104,17 +104,19 @@
                         </tr>
                     </thead>
                     <tbody>
-                    @allVotes.map { case (proposal, voteAndTotalVotes, gtScore, gtVoteCast, maybeMyVote) =>
+                    @allVotes.map { case (proposal, maybeVoteAndTotalVotes, gtScore, gtVoteCast, maybeMyVote) =>
                         @defining(ApprovedProposal.isRefused(proposal.id, proposal.talkType.id)) { refused =>
                             @defining(ApprovedProposal.isApproved(proposal.id, proposal.talkType.id)) { approved =>
                                 <tr class="preselected_@approved refused_@refused">
                                     <td class="number_table"/>
                                     <td class="average_table">
-                                    @defining(voteAndTotalVotes._4) { average: AverageNote =>
-                                        <span class="score" data-score="@average.n.round">
-                                            <span class="btn displayed-score"> @average.n</span>
-                                        </span>
-                                    }
+                                        @maybeVoteAndTotalVotes.map { voteAndTotalVotes =>
+                                            @defining(voteAndTotalVotes._4) { average: AverageNote =>
+                                                <span class="score" data-score="@average.n.round">
+                                                    <span class="btn displayed-score"> @average.n</span>
+                                                </span>
+                                            }
+                                        }.getOrElse { - }
                                     </td>
                                     <td class="gt-votes">
                                         <small>
@@ -124,23 +126,33 @@
                                             by @gtVoteCast <i class="fas fa-user"></i>
                                         </small>
                                     </td>
-                                    <td class="number_table">
-                                    @defining(voteAndTotalVotes._2) { totalVoters: TotalVoter =>
-                                        @totalVoters.i
-                                    }
-                                    </td>
-                                    <td class="number_table">
-                                    @defining(voteAndTotalVotes._3) { totalAbstentions: TotalAbst =>
-                                        @totalAbstentions.i
-                                    }
-                                    </td>
-                                    <td class="number_table gt-votes">
+                                    @maybeVoteAndTotalVotes.map { voteAndTotalVotes =>
+                                        <td class="number_table">
+                                            @defining(voteAndTotalVotes._2) { totalVoters: TotalVoter =>
+                                                @totalVoters.i
+                                            }
+                                        </td>
+                                        <td class="number_table">
+                                            @defining(voteAndTotalVotes._3) { totalAbstentions: TotalAbst =>
+                                                @totalAbstentions.i
+                                            }
+                                        </td>
+                                        <td class="number_table gt-votes">
                                         @defining(library.Stats.average(List(if(gtVoteCast>0){gtScore}else{voteAndTotalVotes._4.n}, voteAndTotalVotes._4.n))) { gtAndComiteeScore: Double =>
                                             <span class="score" data-score="@gtAndComiteeScore.round">
                                                 <span class="btn displayed-score">@gtAndComiteeScore</span>
                                             </span>
                                         }
-                                    </td>
+                                        </td>
+                                    }.getOrElse {
+                                        <td class="number_table">0</td>
+                                        <td class="number_table">0</td>
+                                        <td class="number_table gt-votes">
+                                            <span class="score" data-score="@gtScore.round">
+                                                <span class="btn displayed-score">@gtScore</span>
+                                            </span>
+                                        </td>
+                                    }
                                     @maybeMyVote.map { score =>
                                         <td class="number_table my-votes" data-order="@score.intValue()">
                                             <span class="score" data-score="@score.intValue()">


### PR DESCRIPTION
This PR is a continuation of #275 (will rebase it once merged) and introduces a small change in behaviour regarding all votes retrieval : 

### Before (currently, reviews-centric)

```
1/ Loading all reviews
2/ Loading all proposals having at least 1 review
3/ Browsing reviews and building AllVote row based on review + proposal infos
4/ Filtering AllVote row based on selected type/track
```

### After

```
1/ Loading all reviews
2/ Loading every proposal IDs based on selected type/track
3/ Loading only Proposal matching those proposal IDs
4/ Browsing every proposals and building AllVote row based on review + proposal infos
```

Steps 2 & 3 are introducing 1 or 2 new redis queries : 
- Always : `SUNION Proposals:ByState:SUBMITTED Proposals:ByState:APPROVED Proposals:ByState:REJECTED Proposals:ByState:ACCEPTED Proposals:ByState:DECLINED Proposals:ByState:BACKUP Proposals:ByState:CANCELLED`
- When `track` **and** `type` are defined : `SINTER Proposals:ByType:${confType.id} Proposals:ByTrack:${track.id}`
- When `track` is defined only : `SMEMBER Proposals:ByTrack:${track.id}`
- When `type` is defined only : `SMEMBER Proposals:ByType:${confType.id}`

All those operation should be very fast, and the goal is to have these operations being executed faster than the JSON deserialization which is presently called for useless proposals.
Typically : 
- When we're filtering proposals a lot (let's say we're showing 100 proposal out of 800), then we're avoiding 700 JSON deserialization at the cost of those 1-2 additional redis queries
- But if we're not filtering much proposals (let's say we're showing 750 proposal out of 800) we're making 1-2 additional redis queries for nothing.

I doubt we will frequently want to show "all proposals (no matter the conf type)" on allVotes screen, that's why I'm betting this could be a good performance improvement (only if the 2 additional queries are not too long on production)