### PR TITLE
[feature] Compress HTML pages by default

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,25 +1,23 @@
-import java.util.concurrent.TimeUnit
-
-import library.search.{StopIndex, _}
-import library.{DraftReminder, _}
-import models.{Digest, Proposal}
+import filters.CustomGzipFilter
+import library.search._
+import library._
+import models.Digest
 import org.joda.time.format.DateTimeFormatterBuilder
 import org.joda.time.{DateMidnight, DateTime, LocalTime}
 import play.api.Play.current
 import play.api._
 import play.api.libs.concurrent._
-import play.api.mvc.{RequestHeader, Result}
 import play.api.mvc.Results._
+import play.api.mvc.{RequestHeader, WithFilters}
 import play.core.Router.Routes
 
-import scala.util.control.NonFatal
+import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
 // We must import the compiled cfp error page
-import views.html.cfpErrorPage
 
-object Global extends GlobalSettings {
+object Global extends WithFilters(new CustomGzipFilter()) with GlobalSettings {
   override def onStart(app: Application) {
     Play.current.configuration.getBoolean("actor.cronUpdater.active") match {
       case Some(true) if Play.isProd =>

--- a/app/filters/CustomGzipFilter.scala
+++ b/app/filters/CustomGzipFilter.scala
@@ -1,0 +1,21 @@
+package filters
+
+import play.api.Play
+import play.api.mvc.{EssentialAction, RequestHeader}
+import play.filters.gzip.GzipFilter
+
+class CustomGzipFilter extends GzipFilter {
+
+  override def apply(next: EssentialAction) = {
+    if (Play.current.configuration.getBoolean("cfp.activateGZIP").getOrElse(true)) {
+      super.apply(next);
+    } else {
+      new EssentialAction {
+        def apply(request: RequestHeader) = {
+          next(request)
+        }
+      }
+    }
+  }
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -129,6 +129,10 @@ goldenTicket.active=${ACTIVATE_GOLDEN_TICKET}
 # Set to true if you have HTTPS enabled
 cfp.activateHTTPS=${ACTIVATE_HTTPS}
 
+cfp.activateGZIP=true
+# Set to false to disable GZIP
+cfp.activateGZIP=${? ACTIVATE_GZIP}
+
 # For SSL support
 trustxforwarded=true
 

--- a/conf/application.conf.prod
+++ b/conf/application.conf.prod
@@ -125,6 +125,10 @@ goldenTicket.active=${ACTIVATE_GOLDEN_TICKET}
 # Set to true if you have HTTPS enabled
 cfp.activateHTTPS=${ACTIVATE_HTTPS}
 
+cfp.activateGZIP=true
+# Set to false to disable GZIP
+cfp.activateGZIP=${? ACTIVATE_GZIP}
+
 # For SSL suppoer
 trustxforwarded=true
 


### PR DESCRIPTION
It's useful for dynamic resources which are not in the browser cache.
We can reduce the download page from few Mb to few Kb

`ACTIVATE_GZIP=false` can be used to disable it

# With `ACTIVATE_GZIP=false`

![Screenshot 2022-01-24 at 12 23 40](https://user-images.githubusercontent.com/174600/150775096-817e03fd-8fac-47d3-a871-32421dea17b8.png)


# Without `ACTIVATE_GZIP=false`

![Screenshot 2022-01-24 at 12 24 19](https://user-images.githubusercontent.com/174600/150775118-bfbef942-bf30-44cb-bc8d-55902535a545.png)

**While the difference is not significative on localhost (it's very quick to DL several Mbs) it will have an impact in production**

