### PR TITLE
allVotes' 1 col should be the rank + improved colors for average scores

### DIFF
--- a/app/controllers/CFPAdmin.scala
+++ b/app/controllers/CFPAdmin.scala
@@ -478,7 +478,13 @@ object CFPAdmin extends SecureCFPController {
             case Some(p) =>
               val goldenTicketScore: Double = ReviewByGoldenTicket.averageScore(p.id)
               val gtVoteCast: Long = ReviewByGoldenTicket.totalVoteCastFor(p.id)
-              Option(p, scoreAndVotes, goldenTicketScore, gtVoteCast, allMyVotes.get(p.id))
+              val gtAndComiteeScore = library.Stats.average(
+                List(
+                  if(gtVoteCast>0){goldenTicketScore}else{scoreAndVotes._4.n},
+                  scoreAndVotes._4.n
+                )
+              )
+              Option(p, scoreAndVotes, goldenTicketScore, gtVoteCast, gtAndComiteeScore, allMyVotes.get(p.id))
           }
       }, "create list of Proposals")
 

--- a/app/library/Scores.scala
+++ b/app/library/Scores.scala
@@ -1,0 +1,39 @@
+package library
+
+import com.sksamuel.elastic4s.requests.searches.sort.ScriptSortType.Number
+
+object Scores {
+  /**
+    * Let's say :
+    * - we have 490 conference ratings
+    * - we are planning to keep only 96 conference
+    *
+    * We are going to consider 2 different linear scales :
+    * - 1 from ranks 0->96
+    * - 1 from ranks 97->490
+    *
+    * Now, let's consider we have :
+    * - rated 7.5 a conference talk
+    * - our 7.5 rating comes at rank 90 out of these 490 conference ratings
+    * => Then the "score" of this talk will be 10 - roundFloor((90 / 96)x5) = 6
+    *
+    * Now with :
+    * - rate of 9.2
+    * - this rating coming at rank 13 out of these 490 conference ratings
+    * => Then the "score" of this talk will be 10 - roundFloor((13 / 96)x5) = 10
+    *
+    * And finally with :
+    * - rate of 6.1
+    * - this rating coming at rank 330 out of these 490 conference ratings
+    * => Then the "score" of this talk will be 5 - roundFloor( ((330-96) / (490-96))x4 ) = 3
+    */
+  def calculateVisualScoreOf(value: Double, availableSlots: Long, availableSortedScores: List[Double]): Long = {
+    availableSortedScores.zipWithIndex.find(_._1==value).map{ case (_, valueIndex) =>
+      (if(valueIndex <= availableSlots) {
+        10 - Math.floor(valueIndex*5 / availableSlots)
+      } else {
+        5 - Math.floor((valueIndex - availableSlots)*4 / (availableSortedScores.size - availableSlots))
+      }).toLong
+    }.getOrElse(0)
+  }
+}

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -1,4 +1,4 @@
-@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long, Option[Double])], totalApproved: Long, totalRemaining: Long, confType: String, selectedTrack: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
+@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long, Double, Option[Double])], totalApproved: Long, totalRemaining: Long, confType: String, selectedTrack: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
     @import models.Review.{AverageNote, TotalAbst, TotalVoter}
 
     @main("All votes") {
@@ -104,7 +104,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                    @allVotes.sortBy(-_._2._4.n).zipWithIndex.map { case ((proposal, voteAndTotalVotes, gtScore, gtVoteCast, maybeMyVote), index) =>
+                    @allVotes.sortBy(-_._2._4.n).zipWithIndex.map { case ((proposal, voteAndTotalVotes, gtScore, gtVoteCast, gtAndComiteeScore, maybeMyVote), index) =>
                         @defining(ApprovedProposal.isRefused(proposal.id, proposal.talkType.id)) { refused =>
                             @defining(ApprovedProposal.isApproved(proposal.id, proposal.talkType.id)) { approved =>
                                 <tr class="preselected_@approved refused_@refused">
@@ -135,11 +135,9 @@
                                     }
                                     </td>
                                     <td class="number_table gt-votes">
-                                        @defining(library.Stats.average(List(if(gtVoteCast>0){gtScore}else{voteAndTotalVotes._4.n}, voteAndTotalVotes._4.n))) { gtAndComiteeScore: Double =>
                                             <span class="score" data-score="@gtAndComiteeScore.round">
                                                 <span class="btn displayed-score">@gtAndComiteeScore</span>
                                             </span>
-                                        }
                                     </td>
                                     @maybeMyVote.map { score =>
                                         <td class="number_table my-votes" data-order="@score.intValue()">

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -2,6 +2,13 @@
     @import models.Review.{AverageNote, TotalAbst, TotalVoter}
 
     @main("All votes") {
+        @defining((
+            allVotes.map(_._2._4.n).sorted.reverse,
+            allVotes.map(_._3).sorted.reverse,
+            allVotes.map(_._5).sorted.reverse,
+            allVotes.count(_._1.state == ProposalState.DECLINED)
+        )) { case (sortedComiteeAverageScores: List[Double], sortedGTAverageScores: List[Double], sortedGTAndComiteeScores: List[Double], declinedTotal: Int) =>
+
         <script type="text/javascript" charset="utf-8" language="javascript" src="//cdn.datatables.net/1.10.11/js/jquery.dataTables.min.js"></script>
         <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.11/css/jquery.dataTables.min.css">
 
@@ -67,11 +74,9 @@
                 }
             </div>
             <div class="col-md-12 mt-2">
-                @defining(allVotes.count(_._1.state == ProposalState.DECLINED)) { declinedTotal =>
-                    <span class="badge badge-success">@totalApproved approved</span> <span class="badge badge-declined">
-                        - @declinedTotal declined</span> <span class="badge badge-warning">
-                        = @(totalRemaining + declinedTotal) remaining</span>
-                }
+                <span class="badge badge-success">@totalApproved approved</span> <span class="badge badge-declined">
+                    - @declinedTotal declined</span> <span class="badge badge-warning">
+                    = @(totalRemaining + declinedTotal) remaining</span>
                 <br>
                 <span class="badge badge-primary">@allVotes.map(_._1).count(_.lang == "fr")
                     FR</span> <span class="badge badge-secondary">@allVotes.map(_._1).count(_.lang == "en") EN</span>
@@ -111,14 +116,14 @@
                                     <td class="number_table">@{index+1}</td>
                                     <td class="average_table">
                                     @defining(voteAndTotalVotes._4) { average: AverageNote =>
-                                        <span class="score" data-score="@average.n.round">
+                                        <span class="score" data-score="@library.Scores.calculateVisualScoreOf(average.n, totalRemaining + declinedTotal, sortedComiteeAverageScores)">
                                             <span class="btn displayed-score"> @average.n</span>
                                         </span>
                                     }
                                     </td>
                                     <td class="gt-votes">
                                         <small>
-                                            <span class="score" data-score="@gtScore.round">
+                                            <span class="score" data-score="@library.Scores.calculateVisualScoreOf(gtScore, totalRemaining + declinedTotal, sortedGTAverageScores)">
                                                 <span class="btn-sm displayed-score">@gtScore</span>
                                             </span>
                                             by @gtVoteCast <i class="fas fa-user"></i>
@@ -135,9 +140,9 @@
                                     }
                                     </td>
                                     <td class="number_table gt-votes">
-                                            <span class="score" data-score="@gtAndComiteeScore.round">
-                                                <span class="btn displayed-score">@gtAndComiteeScore</span>
-                                            </span>
+                                        <span class="score" data-score="@library.Scores.calculateVisualScoreOf(gtAndComiteeScore, totalRemaining + declinedTotal, sortedGTAndComiteeScores)">
+                                            <span class="btn displayed-score">@gtAndComiteeScore</span>
+                                        </span>
                                     </td>
                                     @maybeMyVote.map { score =>
                                         <td class="number_table my-votes" data-order="@score.intValue()">
@@ -314,5 +319,5 @@
                 function showProposalType(show) { [10].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }
                 function showTrack(show) { [9].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }
         </script>
-
+        }
     }

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -104,11 +104,11 @@
                         </tr>
                     </thead>
                     <tbody>
-                    @allVotes.map { case (proposal, voteAndTotalVotes, gtScore, gtVoteCast, maybeMyVote) =>
+                    @allVotes.sortBy(-_._2._4.n).zipWithIndex.map { case ((proposal, voteAndTotalVotes, gtScore, gtVoteCast, maybeMyVote), index) =>
                         @defining(ApprovedProposal.isRefused(proposal.id, proposal.talkType.id)) { refused =>
                             @defining(ApprovedProposal.isApproved(proposal.id, proposal.talkType.id)) { approved =>
                                 <tr class="preselected_@approved refused_@refused">
-                                    <td class="number_table"/>
+                                    <td class="number_table">@{index+1}</td>
                                     <td class="average_table">
                                     @defining(voteAndTotalVotes._4) { average: AverageNote =>
                                         <span class="score" data-score="@average.n.round">
@@ -227,11 +227,11 @@
                         "stateSave": true,
                         "drawCallback": function (oSettings) {
                             /* Need to redo the counters if filtered or sorted */
-                            if (oSettings.bSorted || oSettings.bFiltered) {
-                                for (var i = 0, iLen = oSettings.aiDisplay.length ; i < iLen ; i++) {
-                                    $('td:eq(0)', oSettings.aoData[oSettings.aiDisplay[i]].nTr).html(i + 1);
-                                }
-                            }
+                            // if (oSettings.bSorted || oSettings.bFiltered) {
+                            //     for (var i = 0, iLen = oSettings.aiDisplay.length ; i < iLen ; i++) {
+                            //         $('td:eq(0)', oSettings.aoData[oSettings.aiDisplay[i]].nTr).html(i + 1);
+                            //     }
+                            // }
                         },
                         "aoColumnsDef": [
                             {"bSortable": "false", "bSearchable": "false", "aTargets": 0},


### PR DESCRIPTION
Changed first column displayed on all votes screen should be proposal's rank (based on comitee's average score) instead of row number, so that it gives the information about rank of the proposal when comparing our score with average score.

Changed color scales for average scores as well, replacing a 1-10 linear color scale by a double scale based on remaining slots.

Extracted from the doc : 
```
 Let's say :
 - we have 490 conference ratings
 - we are planning to keep only 96 conference

 We are going to consider 2 different linear scales :
 - 1 from ranks 0->96
 - 1 from ranks 97->490

 Now, let's consider we have :
 - rated 7.5 a conference talk
 - our 7.5 rating comes at rank 90 out of these 490 conference ratings
 => Then the "score" of this talk will be 10 - roundFloor((90 / 96)x5) = 6

 Now with :
 - rate of 9.2
 - this rating coming at rank 13 out of these 490 conference ratings
 => Then the "score" of this talk will be 10 - roundFloor((13 / 96)x5) = 10

 And finally with :
 - rate of 6.1
 - this rating coming at rank 330 out of these 490 conference ratings
 => Then the "score" of this talk will be 5 - roundFloor( ((330-96) / (490-96))x4 ) = 3
```