### PR TITLE
Deliberation quick fixes4

### DIFF
--- a/app/assets/css/cfp.less
+++ b/app/assets/css/cfp.less
@@ -164,6 +164,15 @@ dd.info {
 }
 
 /* for page allVotes */
+table#allProposals.dataTable.order-column tbody tr>.sorting_1,
+table#allProposals.dataTable.order-column tbody tr>.sorting_2,
+table#allProposals.dataTable.order-column tbody tr>.sorting_3,
+table#allProposals.dataTable.display tbody tr>.sorting_1,
+table#allProposals.dataTable.display tbody tr>.sorting_2,
+table#allProposals.dataTable.display tbody tr>.sorting_3 {
+  background-color: rgba(0,0,0,0.1)
+}
+
 .preselected_true {
   background-color: #fff8ba !important; // Attention dataTable vire le background pour mettre son bleu
   border-style: solid;
@@ -172,8 +181,6 @@ dd.info {
 }
 
 .average_table {
-  background-color: lightgrey;
-  color: #000;
   text-align: center;
   vertical-align: bottom;
   font-weight: bold;

--- a/app/assets/css/cfp.less
+++ b/app/assets/css/cfp.less
@@ -165,10 +165,10 @@ dd.info {
 
 /* for page allVotes */
 .preselected_true {
-  background-color: #ffff00 !important; // Attention dataTable vire le background pour mettre son bleu
+  background-color: #fff8ba !important; // Attention dataTable vire le background pour mettre son bleu
   border-style: solid;
   border-width: 2px;
-  border-color: #ffff00;
+  border-color: #fff8ba;
 }
 
 .average_table {

--- a/app/library/Scores.scala
+++ b/app/library/Scores.scala
@@ -27,8 +27,13 @@ object Scores {
     */
   def calculateVisualScoreOf(value: Double, availableSlots: Long, availableSortedScores: List[Double]): Long = {
     availableSortedScores.zipWithIndex.find(_._1 == value).map { case (_, valueIndex) =>
-      (if (valueIndex < availableSlots) {
+      (if(availableSlots <= 0) {
+        // Once we've filled every available slots, using only a single (linear) scale
+        10 - Math.floor(valueIndex * 9 / availableSortedScores.size)
+      } else if (valueIndex < availableSlots) {
+        // in the [0-availableSlots[ range, retrieving linear score from this range between 6-10
         10 - Math.floor(valueIndex * 5 / availableSlots)
+        // in the [availableSlots, availableSortedScores.size[, retrieving linear score from this range between 1-5
       } else {
         5 - Math.floor((valueIndex - availableSlots) * 4 / (availableSortedScores.size - availableSlots))
       }).toLong

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -311,14 +311,22 @@
 
                     @if(confType=="all"){ $("#showProposalType").attr('checked', true); }
                     @if(selectedTrack=="all"){ $("#showTrack").attr('checked', true); }
+                    $("#showMyVotes").attr('checked', localStorage.getItem("showMyVotes")==="true")
+                    $("#showGTVotes").attr('checked', localStorage.getItem("showGTVotes")==="true")
 
-                    ["#showProposalType", "#showTrack", "#showMyVotes", "#showGTVotes"].forEach(selector => $(selector).change());
+                    $.each(["#showProposalType", "#showTrack", "#showMyVotes", "#showGTVotes"], (_, selector) => $(selector).change());
                 });
 
-                function showMyVotes(show) { [6].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }
-                function showGTVotes(show) { [2,5].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }
-                function showProposalType(show) { [10].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }
-                function showTrack(show) { [9].forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show)); }
+                function changeColumnsVisibility(colIndexes, show, localstorageKey) {
+                    colIndexes.forEach(colIndex => $('#allProposals').dataTable().fnSetColumnVis(colIndex, show));
+                    if(localstorageKey) {
+                        localStorage.setItem(localstorageKey, ""+show);
+                    }
+                }
+                function showMyVotes(show) { changeColumnsVisibility([6], show, "showMyVotes"); }
+                function showGTVotes(show) { changeColumnsVisibility([2,5], show, "showGTVotes"); }
+                function showProposalType(show) { changeColumnsVisibility([10], show); }
+                function showTrack(show) { changeColumnsVisibility([9], show); }
         </script>
         }
     }

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -6,8 +6,9 @@
             allVotes.map(_._2._4.n).sorted.reverse,
             allVotes.map(_._3).sorted.reverse,
             allVotes.map(_._5).sorted.reverse,
-            allVotes.count(_._1.state == ProposalState.DECLINED)
-        )) { case (sortedComiteeAverageScores: List[Double], sortedGTAverageScores: List[Double], sortedGTAndComiteeScores: List[Double], declinedTotal: Int) =>
+            allVotes.count(_._1.state == ProposalState.DECLINED),
+            totalRemaining + allVotes.count(_._1.state == ProposalState.DECLINED)
+        )) { case (sortedComiteeAverageScores: List[Double], sortedGTAverageScores: List[Double], sortedGTAndComiteeScores: List[Double], declinedTotal: Int, remainingIncludingDeclined: Long) =>
 
         <script type="text/javascript" charset="utf-8" language="javascript" src="//cdn.datatables.net/1.10.11/js/jquery.dataTables.min.js"></script>
         <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.11/css/jquery.dataTables.min.css">
@@ -76,7 +77,7 @@
             <div class="col-md-12 mt-2">
                 <span class="badge badge-success">@totalApproved approved</span> <span class="badge badge-declined">
                     - @declinedTotal declined</span> <span class="badge badge-warning">
-                    = @(totalRemaining + declinedTotal) remaining</span>
+                    = @remainingIncludingDeclined remaining</span>
                 <br>
                 <span class="badge badge-primary">@allVotes.map(_._1).count(_.lang == "fr")
                     FR</span> <span class="badge badge-secondary">@allVotes.map(_._1).count(_.lang == "en") EN</span>
@@ -116,14 +117,14 @@
                                     <td class="number_table">@{index+1}</td>
                                     <td class="average_table">
                                     @defining(voteAndTotalVotes._4) { average: AverageNote =>
-                                        <span class="score" data-score="@library.Scores.calculateVisualScoreOf(average.n, totalRemaining + declinedTotal, sortedComiteeAverageScores)">
+                                        <span class="score" data-score="@library.Scores.calculateVisualScoreOf(average.n, remainingIncludingDeclined, sortedComiteeAverageScores)">
                                             <span class="btn displayed-score"> @average.n</span>
                                         </span>
                                     }
                                     </td>
                                     <td class="gt-votes">
                                         <small>
-                                            <span class="score" data-score="@library.Scores.calculateVisualScoreOf(gtScore, totalRemaining + declinedTotal, sortedGTAverageScores)">
+                                            <span class="score" data-score="@library.Scores.calculateVisualScoreOf(gtScore, remainingIncludingDeclined, sortedGTAverageScores)">
                                                 <span class="btn-sm displayed-score">@gtScore</span>
                                             </span>
                                             by @gtVoteCast <i class="fas fa-user"></i>
@@ -140,7 +141,7 @@
                                     }
                                     </td>
                                     <td class="number_table gt-votes">
-                                        <span class="score" data-score="@library.Scores.calculateVisualScoreOf(gtAndComiteeScore, totalRemaining + declinedTotal, sortedGTAndComiteeScores)">
+                                        <span class="score" data-score="@library.Scores.calculateVisualScoreOf(gtAndComiteeScore, remainingIncludingDeclined, sortedGTAndComiteeScores)">
                                             <span class="btn displayed-score">@gtAndComiteeScore</span>
                                         </span>
                                     </td>


### PR DESCRIPTION
Some quick fixes (again) : 

- Storing "Show my vote" and "Show GT Votes" choices on allVotes screen in localstorage, so that we keep its value across navigations

- Improved a little bit the colors on allVotes screen, using a less aggressive yellow + removed greyed background on sorted columns
<img width="800" alt="All_votes_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/150899989-d3d7cc8d-1924-424f-9dbf-9ffe8cd1bee6.png">

- When no available slot remains, using the whole color space (from red to green) for average scores, instead of the red -> yellow color space (second part of the score scales introduced yesterday)

