### PR TITLE
Introduced floating line for new comments on proposals

### DIFF
--- a/app/assets/css/cfp.less
+++ b/app/assets/css/cfp.less
@@ -922,6 +922,14 @@ div.chat_list {
   background-color: #f6f6f6;
 }
 
+div.chat_new_comments_indicator {
+  text-align: center;
+  background-color: #f6f6f6;
+  border-top: 1px solid red;
+  color: red;
+  border-bottom: 1px solid red;
+}
+
 div.chat_people {
   overflow: hidden;
   clear: both;

--- a/app/controllers/CFPAdmin.scala
+++ b/app/controllers/CFPAdmin.scala
@@ -91,7 +91,8 @@ object CFPAdmin extends SecureCFPController {
     val proposalsByAuths = allProposalByProposal(proposal)
     val userWatchPref = ProposalUserWatchPreference.proposalUserWatchPreference(proposal.id, userId)
     val maybeDelayedReviewReason = Review.proposalDelayedReviewReason(userId, proposal.id)
-    views.html.CFPAdmin.showProposal(proposal, proposalsByAuths, speakerDiscussion, internalDiscussion, msgToSpeakerForm, msgInternalForm, voteForm, maybeMyVote, maybeMyPreviousVote, userId, userWatchPref, maybeDelayedReviewReason)
+    val proposalLastVisit = Proposal.userProposalLastVisits(userId).get(proposal.id)
+    views.html.CFPAdmin.showProposal(proposal, proposalsByAuths, speakerDiscussion, internalDiscussion, msgToSpeakerForm, msgInternalForm, voteForm, maybeMyVote, maybeMyPreviousVote, userId, userWatchPref, maybeDelayedReviewReason, proposalLastVisit)
   }
 
   def openForReview(proposalId: String) = SecuredAction(IsMemberOf("cfp")) {

--- a/app/views/CFPAdmin/showProposal.scala.html
+++ b/app/views/CFPAdmin/showProposal.scala.html
@@ -1,4 +1,4 @@
-@(proposal: Proposal, proposalsByAuths: Map[String, Map[String, Proposal]], speakerComments: List[Comment], internalComments: List[Comment], msgToSpeakerForm: Form[String], msgInternalForm: Form[String], voteForm: Form[Int], maybeMyVote: Option[Review], maybeMyPreviousVote: Option[Review], currentUser: String, userWatchPref: ProposalUserWatchPreference, maybeVoteDelayedReason: Option[String])(implicit flash: Flash, lang: Lang, req: RequestHeader)
+@(proposal: Proposal, proposalsByAuths: Map[String, Map[String, Proposal]], speakerComments: List[Comment], internalComments: List[Comment], msgToSpeakerForm: Form[String], msgInternalForm: Form[String], voteForm: Form[Int], maybeMyVote: Option[Review], maybeMyPreviousVote: Option[Review], currentUser: String, userWatchPref: ProposalUserWatchPreference, maybeVoteDelayedReason: Option[String], proposalLastVisit: Option[org.joda.time.DateTime])(implicit flash: Flash, lang: Lang, req: RequestHeader)
 
 @main("[CFP] " + proposal.id + "/" + proposal.title) {
     <div class="row">
@@ -258,7 +258,7 @@
                     }
                     </div>
                     <div class="card-body">
-                    @tags.renderComments(speakerComments)
+                    @tags.renderComments(speakerComments, proposalLastVisit)
                     </div>
                 </div>
             </div>
@@ -306,7 +306,7 @@
                     }
                     </div>
                     <div class="card-body">
-                    @tags.renderComments(internalComments)
+                    @tags.renderComments(internalComments, proposalLastVisit)
                     </div>
                 </div>
 

--- a/app/views/CallForPaper/showCommentForProposal.scala.html
+++ b/app/views/CallForPaper/showCommentForProposal.scala.html
@@ -52,7 +52,7 @@
                 </div>
 
                 <div class="card-body">
-                @tags.renderComments(comments)
+                @tags.renderComments(comments, None)
                 </div>
             </div>
         </div>

--- a/app/views/tags/renderComments.scala.html
+++ b/app/views/tags/renderComments.scala.html
@@ -1,35 +1,42 @@
-@(comments: List[models.Comment])
-  @comments.map { c =>
-        @models.Speaker.findByUUID(c.uuidAuthor).map { speaker =>
-            @models.Webuser.findByUUID(c.uuidAuthor).map { webuser =>
-<div class="chat_list">
-  <div class="chat_people">
-    <div class="chat_img">
-                @if(speaker.avatarUrl.isEmpty) {
-      <img class="media-object" width="35" src="//www.gravatar.com/avatar/@Webuser.gravatarHash(webuser.email)?s=35" alt="@webuser.cleanName" title="@webuser.cleanName"/>
-                } else {
-      <img class="media-object" width="35" src="@speaker.avatarUrl.get" alt="@webuser.cleanName" title="@webuser.cleanName"/>
-                }
-    </div>
-    <div class="chat_ib">
-      <h5>
-        <a  href="@routes.CFPAdmin.showSpeakerAndTalks(c.uuidAuthor)">@webuser.cleanName</a>
-        <span class="chat_date"> @Messages("tags.renderComment.postedBy",
-            library.FormatDate.jodaDateFormat(c.eventDate.get, play.api.i18n.Lang.defaultLang),
-            library.FormatDate.jodaTimeFormat(c.eventDate.get, play.api.i18n.Lang.defaultLang))</span>
-      </h5>
-                @defining(c.msg.replaceAll("script", ".script").replaceAll("\n", "<br>")) { message: String =>
-      <p>@Html(message)</p>
-                    @models.Proposal.ProposalIDRegExp.findAllIn(message).map { proposalIdRef =>
-      <p>@tags.linkToProposal(proposalIdRef)</p>
-                    }
-                    @models.Proposal.HttpUrl.findAllIn(message).map { test =>
-      <p><a href="@test" target="_blank"><i class="fas fa-external-link"></i> @test</a></p>
-                    }
-                }
-    </div>
-  </div>
-</div>
-            }
+@(comments: List[models.Comment], maybeProposalLastVisit: Option[org.joda.time.DateTime])
+  @defining(comments.reverse.find{ comment => maybeProposalLastVisit.map { proposalLastVisit => proposalLastVisit.isBefore(comment.eventDate.get) }.getOrElse(true) }){ maybeFirstUnwatchedComment: Option[Comment] =>
+    @comments.zipWithIndex.map{ case (c, index) =>
+      @models.Speaker.findByUUID(c.uuidAuthor).map { speaker =>
+        @models.Webuser.findByUUID(c.uuidAuthor).map { webuser =>
+        <div class="chat_list">
+          <div class="chat_people">
+            <div class="chat_img">
+              @if(speaker.avatarUrl.isEmpty) {
+                <img class="media-object" width="35" src="//www.gravatar.com/avatar/@Webuser.gravatarHash(webuser.email)?s=35" alt="@webuser.cleanName" title="@webuser.cleanName"/>
+              } else {
+                <img class="media-object" width="35" src="@speaker.avatarUrl.get" alt="@webuser.cleanName" title="@webuser.cleanName"/>
+              }
+            </div>
+            <div class="chat_ib">
+              <h5>
+                <a  href="@routes.CFPAdmin.showSpeakerAndTalks(c.uuidAuthor)">@webuser.cleanName</a>
+                <span class="chat_date"> @Messages("tags.renderComment.postedBy",
+                  library.FormatDate.jodaDateFormat(c.eventDate.get, play.api.i18n.Lang.defaultLang),
+                  library.FormatDate.jodaTimeFormat(c.eventDate.get, play.api.i18n.Lang.defaultLang))</span>
+              </h5>
+              @defining(c.msg.replaceAll("script", ".script").replaceAll("\n", "<br>")) { message: String =>
+                <p>@Html(message)</p>
+              @models.Proposal.ProposalIDRegExp.findAllIn(message).map { proposalIdRef =>
+                <p>@tags.linkToProposal(proposalIdRef)</p>
+              }
+              @models.Proposal.HttpUrl.findAllIn(message).map { test =>
+                <p><a href="@test" target="_blank"><i class="fas fa-external-link"></i> @test</a></p>
+              }
+              }
+            </div>
+          </div>
+        </div>
+          @if(maybeFirstUnwatchedComment.map(c == _).getOrElse(false)) {
+            <div class="chat_new_comments_indicator">
+              <i class="fas fa-arrow-alt-circle-up"></i> @Messages("tags.renderComment.newMessages") <i class="fas fa-arrow-alt-circle-up"></i>
+            </div>
+          }
         }
+      }
+    }
   }

--- a/conf/messages
+++ b/conf/messages
@@ -444,6 +444,7 @@ admin.draft.warning3=Current proposal state :
 newProposal.maxLength=Max size is 1200 characters (including Markdown characters, if you want to use it)
 preview.txt=Preview Conference guide (sample page)
 tags.renderComment.postedBy=Posted on {0} at {1}
+tags.renderComment.newMessages=New messages
 
 admin.btn.sponsor=VIP view on proposals
 leaderboard.compute=Computing stats

--- a/conf/messages.fr
+++ b/conf/messages.fr
@@ -383,6 +383,7 @@ admin.draft.warning3=Etat actuel de cette proposition :
 newProposal.maxLength=Maximum 1200 caractères. Possibilité d''utiliser Markdown
 preview.txt=Aperçu de votre présentation dans le programme papier
 tags.renderComment.postedBy=Posté le {0} à {1}
+tags.renderComment.newMessages=Nouveaux messages
 admin.btn.sponsor=Voir comme un sponsor
 leaderboard.compute=Calcul des stats en cours...
  


### PR DESCRIPTION
⚠️ testing still in progress - @aheritier found something which was maybe a bug in #285 comments : 
> I am not able to test the floating new messages feature for now because I already read all my notifications
> Doing some random tests I saw the "Nouveaux messages" on the private window of QWC-2883 but it's strange because my counter of notifications is empty. It's the only talk I found like this ...

This PR brings a floating chronological line to identify new messages appeared since our last visit on a proposal : 
![image](https://user-images.githubusercontent.com/603815/153706522-0afa9946-df46-4c52-abb8-a05eaac6a998.png)

