### PR TITLE
Schedule fixes

### DIFF
--- a/app/models/Slot.scala
+++ b/app/models/Slot.scala
@@ -96,6 +96,10 @@ object Room {
     "neu_232_232",
     "neu_234_235",
     "neu_212_213",
+    "lab1",
+    "lab2",
+    "lab3",
+    "lab4",
     "x_hall_a"
   )
 


### PR DESCRIPTION
This PR brings some fixes on schedule generation : 
- We were having `ArrayIndexOutOfBoundsException` when generating schedule with slot fillers by the end of the day (see #290) 
- Due to lab rooms not being declared into `Room.fixedOrderForRoom`, those rooms were considered as first rooms, and were preventing to generate break labels

<img width="1024px" alt="Wednesday_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/153732508-b43fe928-30e4-4a52-b0b9-47f9798c6236.png">

