### PR TITLE
Improved color contrast for uni/lab slots in schedule

### DIFF
--- a/public/dvfr2015/schedule.css
+++ b/public/dvfr2015/schedule.css
@@ -156,8 +156,8 @@
     padding: 4px;
 }
 
-.proposal_type_is_uni { background-color: #deccfe; }
-.proposal_type_is_lab { background-color: #f87ef6; }
+.proposal_type_is_uni { background-color: #d8c2ff; }
+.proposal_type_is_lab { background-color: #fddcfd; }
 .proposal_type_is_conf { background-color: #ccfecc; }
 .proposal_type_is_tia { background-color: #daeff4; }
 .proposal_type_is_quick { background-color: #fffec3; }


### PR DESCRIPTION
Before : 

<img width="1024px" alt="Wednesday_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/154375567-fa2019e1-04e6-4bd7-afa6-10ddf0aa56c6.png">


After : 

<img width="1024px" alt="Wednesday_-_Devoxx_France_2022" src="https://user-images.githubusercontent.com/603815/154375602-a3f6e33c-30f6-48f0-bbff-d5dafb22962a.png">

