### PR TITLE
Showing statistics on my votes screen

### DIFF
--- a/app/assets/css/cfp.less
+++ b/app/assets/css/cfp.less
@@ -721,6 +721,19 @@ progress:after {
  border-color: #2b7c21;
 }
 
+.score-bar-chart {
+  display: grid;
+  grid-column-gap: 5px;
+  height: 90%;
+  width: 100%;
+  padding: 5px 10px;
+}
+
+.bar-score {
+  border-radius: 5px 5px 0 0;
+  transition: all .6s ease;
+}
+
 .btn-vote{
   color: #fff;
   background-color:#2d7eec;

--- a/app/assets/css/cfp.less
+++ b/app/assets/css/cfp.less
@@ -655,67 +655,67 @@ progress:after {
   right: 0;
 }
 
-.btn-color-0, .score[data-score='0'] .displayed-score {
+.btn-color-0, .score[data-score='0'] .displayed-score, .bar-score[data-score='0'] {
   color: #fff;
   background-color: @lightgrey;
   border-color: @lightgrey;
 }
 
-.btn-color-1, .score .minus, .score[data-score='1'] .displayed-score {
+.btn-color-1, .score .minus, .score[data-score='1'] .displayed-score, .bar-score[data-score='1'] {
  color: #fff;
  background-color: #e4151c;
  border-color: #e2061a;
 }
 
-.btn-color-2, .score[data-score='2'] .displayed-score {
+.btn-color-2, .score[data-score='2'] .displayed-score, .bar-score[data-score='2'] {
   color: #fff;
  background-color: #ed4b24;
  border-color: #e93120;
 }
 
-.btn-color-3, .score[data-score='3'] .displayed-score {
+.btn-color-3, .score[data-score='3'] .displayed-score, .bar-score[data-score='3'] {
  color: #fff;
  background-color: #ed882c;
  border-color: #ed6d29;
 }
 
-.btn-color-4, .score[data-score='4'] .displayed-score {
+.btn-color-4, .score[data-score='4'] .displayed-score, .bar-score[data-score='4'] {
  color: #fff;
  background-color: #edc034;
  border-color: #eda931;
 }
 
-.btn-color-5, .score[data-score='5'] .displayed-score {
+.btn-color-5, .score[data-score='5'] .displayed-score, .bar-score[data-score='5'] {
  color: #fff;
  background-color: #ede038;
  border-color: #edd637;
 }
 
-.btn-color-6, .score[data-score='6'] .displayed-score {
+.btn-color-6, .score[data-score='6'] .displayed-score, .bar-score[data-score='6'] {
  color: #fff;
  background-color: #d0df36;
  border-color: #e1e237;
 }
 
-.btn-color-7, .score[data-score='7'] .displayed-score {
+.btn-color-7, .score[data-score='7'] .displayed-score, .bar-score[data-score='7'] {
  color: #fff;
  background-color: #9cc630;
  border-color: #b4d333;
 }
 
-.btn-color-8, .score .plus, .score[data-score='8'] .displayed-score {
+.btn-color-8, .score .plus, .score[data-score='8'] .displayed-score, .bar-score[data-score='8'] {
  color: #fff;
  background-color: #7cb22c;
  border-color: #63a229;
 }
 
-.btn-color-9, .score[data-score='9'] .displayed-score {
+.btn-color-9, .score[data-score='9'] .displayed-score, .bar-score[data-score='9'] {
  color: #fff;
  background-color: #428b24;
  border-color: #2b7c21;
 }
 
-.btn-color-10, .score[data-score='10'] .displayed-score {
+.btn-color-10, .score[data-score='10'] .displayed-score, .bar-score[data-score='10'] {
  color: #fff;
  background-color: #116a1d;
  border-color: #2b7c21;

--- a/app/models/ConferenceDescriptor.scala
+++ b/app/models/ConferenceDescriptor.scala
@@ -209,6 +209,7 @@ object ConferenceDescriptor {
     val LANG: Track = Track("lang", "lang.label")
     val UNKNOWN: Track = Track("unknown", "unknown track")
     val ALL = List(JAVA, WEB, ARCHISEC, CLOUD, BIGDATA, GEEK, LANG, UNKNOWN)
+    val ALL_KNOWN = ALL.filter(_ != UNKNOWN)
   }
 
   // TODO configure the description for each Track

--- a/app/views/ApproveOrRefuse/allApprovedByTalkType.scala.html
+++ b/app/views/ApproveOrRefuse/allApprovedByTalkType.scala.html
@@ -42,7 +42,7 @@
 
                         <br>
 
-                        <table id="allProposals" class="table table-bordered table-hover table-condensed">
+                        <table id="allProposals" class="table table-bordered table-hover table-sm">
                             <thead>
                                 <tr>
                                     <th>Proposal title</th>

--- a/app/views/ApproveOrRefuse/allRefusedByTalkType.scala.html
+++ b/app/views/ApproveOrRefuse/allRefusedByTalkType.scala.html
@@ -46,7 +46,7 @@
                     <br>
                     <small>If proposal's state = REJECTED then the speaker has been notified.</small>
 
-                    <table id="allProposals" class="table table-bordered table-condensed">
+                    <table id="allProposals" class="table table-bordered table-sm">
                         <thead>
                             <tr>
                                 <th>Score</th>

--- a/app/views/Backoffice/allProposals.scala.html
+++ b/app/views/Backoffice/allProposals.scala.html
@@ -46,7 +46,7 @@
         <div class="card-body">
 
             @if(proposals.nonEmpty){
-            <table id="allProposals" class="table table-bordered table-hover table-condensed" aria-label="all Proposals">
+            <table id="allProposals" class="table table-bordered table-hover table-sm" aria-label="all Proposals">
                 <thead>
                     <tr>
                         <th>Proposal id</th>

--- a/app/views/Backoffice/exportAgenda.scala.html
+++ b/app/views/Backoffice/exportAgenda.scala.html
@@ -15,7 +15,7 @@
 
         <div class="card-body">
 
-    <table id="allProposals" class="table table-condensed table-bordered">
+    <table id="allProposals" class="table table-sm table-bordered">
         <thead>
             <tr>
                 <th>Proposal type</th>

--- a/app/views/Backoffice/showAllDeclined.scala.html
+++ b/app/views/Backoffice/showAllDeclined.scala.html
@@ -33,7 +33,7 @@
         <div class="card-body">
 
             @if(proposals.nonEmpty){
-            <table id="allProposals" class="table table-bordered table-hover table-condensed">
+            <table id="allProposals" class="table table-bordered table-hover table-sm">
                 <thead>
                     <tr>
                         <th>Proposal id</th>

--- a/app/views/Backoffice/showAllProposalsByTags.scala.html
+++ b/app/views/Backoffice/showAllProposalsByTags.scala.html
@@ -33,7 +33,7 @@
         <div class="card-body">
 
         @if(tagProposalEntries.nonEmpty){
-          <table class="table table-bordered table-striped table-hover table-condensed">
+          <table class="table table-bordered table-striped table-hover table-sm">
             <thead>
               <tr>
                 <th>Tag Name</th>

--- a/app/views/Backoffice/showAllTags.scala.html
+++ b/app/views/Backoffice/showAllTags.scala.html
@@ -34,7 +34,7 @@
           <a href="@routes.Backoffice.newTag()" class="btn btn-sm btn-primary">Create a new Tag</a>
           <br><br>
           @if(tags.nonEmpty){
-            <table id="tags" class="table table-bordered table-hover table-condensed">
+            <table id="tags" class="table table-bordered table-hover table-sm">
               <thead>
                 <tr>
                   <th>Tag Name</th>

--- a/app/views/Backoffice/showSelectionByTags.scala.html
+++ b/app/views/Backoffice/showSelectionByTags.scala.html
@@ -32,7 +32,7 @@
         <div class="card-body">
 
         @if(tagProposalEntries.nonEmpty){
-          <table id="tagsTable" class="table table-bordered table-striped table-hover table-condensed">
+          <table id="tagsTable" class="table table-bordered table-striped table-hover table-sm">
             <thead>
               <tr>
                 <th>Tag</th>

--- a/app/views/CFPAdmin/allMyVotes.scala.html
+++ b/app/views/CFPAdmin/allMyVotes.scala.html
@@ -7,7 +7,8 @@
     proposalNotReviewedCountByType: Map[String,Int],
     proposalNotReviewedCountForCurrentTypeByTrack: Map[String,Int],
     firstProposalNotReviewed: Option[Proposal],
-    delayedReviewsCount: Long
+    delayedReviewsCount: Long,
+    reviewerStats: Option[List[NamedReviewerStats]]
 )(implicit lang: Lang, flash: Flash, req:RequestHeader)
 
 @main("All my votes") {
@@ -28,6 +29,9 @@
             <div class="card-body">
                 <div class="col-md-12">
                     <h3><i class="fas fa-flask"></i> Your personnal leaderboard</h3>
+                    @tags.renderNamedReviewerStats(reviewerStats)
+                    <br/>
+
                     @tags.renderMyReviewsSearchCriteria(
                         refreshPathAction=(confType, selectedTrack) => routes.CFPAdmin.allMyVotes(confType, selectedTrack),
                         availableTalkTypes=models.ConferenceDescriptor.ConferenceProposalTypes.ALL,

--- a/app/views/CFPAdmin/allProposalsByTrack.scala.html
+++ b/app/views/CFPAdmin/allProposalsByTrack.scala.html
@@ -37,7 +37,7 @@
 
 
                         <div class="col-md-12">
-                            <table id="allProposals" class="table table-bordered table-hover table-condensed">
+                            <table id="allProposals" class="table table-bordered table-hover table-sm">
                                 <thead>
                                     <tr>
                                         <th>Proposal title</th>

--- a/app/views/CFPAdmin/allProposalsByType.scala.html
+++ b/app/views/CFPAdmin/allProposalsByType.scala.html
@@ -37,7 +37,7 @@
 
 
                         <div class="col-md-12">
-                            <table id="allProposals" class="table table-bordered table-hover table-condensed">
+                            <table id="allProposals" class="table table-bordered table-hover table-sm">
                                 <thead>
                                     <tr>
                                         <th>Proposal title</th>

--- a/app/views/CFPAdmin/allSpeakersWithAcceptedTalksForExport.scala.html
+++ b/app/views/CFPAdmin/allSpeakersWithAcceptedTalksForExport.scala.html
@@ -31,7 +31,7 @@
                 </div>
             </div>
         </div>
-<table class="table table-bordered table-condensed">
+<table class="table table-bordered table-sm">
     <thead>
         <tr>
             <th>Last name</th>

--- a/app/views/CFPAdmin/allVotesVersion2.scala.html
+++ b/app/views/CFPAdmin/allVotesVersion2.scala.html
@@ -49,7 +49,7 @@
                 <br>
                 <a href="@routes.CFPAdmin.allVotesVersion2(confType,page,resultats,"gt_and_cfp")" class="btn btn-primary btn-sm"><i class="icin fas fa-sort-numeric-down"></i> Sort by GT+CFP average score</a> -
                 <a href="@routes.CFPAdmin.allVotesVersion2(confType,page,resultats,"cfp")" class="btn btn-primary btn-sm"><i class="icin fas fa-sort-numeric-down"></i> Sort by CFP score</a>
-                <table id="allProposals" class="table table-condensed">
+                <table id="allProposals" class="table table-sm">
                     <thead>
                         <tr>
                             <th></th>

--- a/app/views/CFPAdmin/cfpAdminIndex.scala.html
+++ b/app/views/CFPAdmin/cfpAdminIndex.scala.html
@@ -69,7 +69,7 @@
                     @if(allProposalsForReview.nonEmpty) {
                         <br>
                         <br>
-                        <table class="table table-bordered table-striped table-hover table-condensed">
+                        <table class="table table-bordered table-striped table-hover table-sm">
                             <thead>
                                 <tr>
                                     <th>Title</th>
@@ -135,7 +135,7 @@
                 </div>
 
                 <div class="card-body">
-                    <table class="table table-bordered table-striped table-hover table-condensed">
+                    <table class="table table-bordered table-striped table-hover table-sm">
                         <thead>
                             <tr>
                                 <th scope="col" style="width: 100px">@Messages("admin.cfp.date")</th>

--- a/app/views/CFPAdmin/showCFPUsers.scala.html
+++ b/app/views/CFPAdmin/showCFPUsers.scala.html
@@ -23,7 +23,7 @@
             @flash.get("success").get
             </div>
             }
-            <table class="table table-striped table-bordered table-condensed">
+            <table class="table table-striped table-bordered table-sm">
                 <thead>
                     <tr>
                         <th>@Messages("firstName") @Messages("lastName")</th>

--- a/app/views/CFPAdmin/showProposalsByTag.scala.html
+++ b/app/views/CFPAdmin/showProposalsByTag.scala.html
@@ -7,7 +7,7 @@
           <h3><i class="fas fa-tags"></i> Found @tags.renderTotalWithLabel(proposals.size, "proposal", "proposals") with '@tag.value' tag</h3>
         </div>
         <div class="card-body">
-            <table class="table table-bordered table-striped table-hover table-condensed">
+            <table class="table table-bordered table-striped table-hover table-sm">
                 <thead>
                     <tr>
                         <th>Title</th>

--- a/app/views/GoldenTicketAdmin/showAll.scala.html
+++ b/app/views/GoldenTicketAdmin/showAll.scala.html
@@ -31,7 +31,7 @@
                 <div class="card-body">
                       <a href="@routes.GoldenTicketAdminController.newGoldenTicket()" class="btn btn-sm btn-primary">Create a new golden ticket</a>
                 @if(tickets.nonEmpty) {
-                    <table id="tickets" class="table table-bordered table-hover table-condensed">
+                    <table id="tickets" class="table table-bordered table-hover table-sm">
                         <thead>
                             <tr>
                                 <th>Golden ticket ID</th>

--- a/app/views/GoldenTicketAdmin/showGoldenTicketVotes.scala.html
+++ b/app/views/GoldenTicketAdmin/showGoldenTicketVotes.scala.html
@@ -18,7 +18,7 @@
             <div class="card-body">
 
                 <div class="col-md-12">
-                    <table id="allProposals" class="table table-bordered table-hover table-condensed">
+                    <table id="allProposals" class="table table-bordered table-hover table-sm">
                         <thead>
                             <tr>
                                 <th></th>

--- a/app/views/GoldenTicketController/allMyGoldenTicketVotes.scala.html
+++ b/app/views/GoldenTicketController/allMyGoldenTicketVotes.scala.html
@@ -6,7 +6,8 @@
     delayedReviewsCount: Long,
     proposalNotReviewedCountByType: Map[String,Int],
     proposalNotReviewedCountForCurrentTypeByTrack: Map[String,Int],
-    firstProposalNotReviewed: Option[Proposal]
+    firstProposalNotReviewed: Option[Proposal],
+    reviewerStats: Option[List[NamedReviewerStats]]
 )(implicit lang: Lang, flash: Flash, req:RequestHeader)
 
 @main("All my votes") {
@@ -21,6 +22,9 @@
             <div class="card-body">
                 <div class="col-md-12">
                     <h3><i class="fas fa-flask"></i> @Messages("gt.personnal")</h3>
+                    @tags.renderNamedReviewerStats(reviewerStats)
+                    <br/>
+
                     @tags.renderMyReviewsSearchCriteria(
                         refreshPathAction=(confType, selectedTrack) => routes.GoldenTicketController.allMyGoldenTicketVotes(confType, selectedTrack),
                         availableTalkTypes=models.ConferenceDescriptor.ConferenceProposalTypes.ALL.filter(models.ConferenceDescriptor.ConferenceProposalConfigurations.accessibleTypeToGoldenTicketReviews(_)),

--- a/app/views/GoldenTicketController/showAllProposalsGT.scala.html
+++ b/app/views/GoldenTicketController/showAllProposalsGT.scala.html
@@ -57,7 +57,7 @@
                         <br>
 
 
-                        <table class="table table-bordered table-striped table-hover table-condensed">
+                        <table class="table table-bordered table-striped table-hover table-sm">
                             <thead>
                                 <tr>
                                     <th>@tags.gticket.renderThTag("title", page, sort, ascdesc)</th>

--- a/app/views/Wishlist/homeWishList.scala.html
+++ b/app/views/Wishlist/homeWishList.scala.html
@@ -33,7 +33,7 @@
                         @flash.get("success").get
                         </div>
                     }
-<table id="allWishList" class="table table-bordered table-hover table-condensed">
+<table id="allWishList" class="table table-bordered table-hover table-sm">
     <thead>
         <tr>
             <th>@Messages("wl.action")</th>

--- a/app/views/Wishlist/showHistory.scala.html
+++ b/app/views/Wishlist/showHistory.scala.html
@@ -19,7 +19,7 @@
                 </div>
 
                 <div class="card-body">
-<table id="historyTable" class="table table-bordered table-hover table-condensed">
+<table id="historyTable" class="table table-bordered table-hover table-sm">
     <thead>
         <tr>
             <th>Status</th>

--- a/app/views/tags/renderDelayedReviews.scala.html
+++ b/app/views/tags/renderDelayedReviews.scala.html
@@ -17,7 +17,7 @@
     @if(proposals.isEmpty) {
       @Messages("admin.proposals.delayed-reviews.empty")
     } else {
-      <table class="table table-bordered table-striped table-hover table-condensed">
+      <table class="table table-bordered table-striped table-hover table-sm">
         <caption>List of delayed reviews</caption>
         <thead>
           <tr>

--- a/app/views/tags/renderNamedReviewerStats.scala.html
+++ b/app/views/tags/renderNamedReviewerStats.scala.html
@@ -1,0 +1,39 @@
+@(
+    maybeReviewerStats: Option[List[NamedReviewerStats]]
+)(implicit lang: Lang, req: RequestHeader)
+@maybeReviewerStats.map { reviewerStats =>
+  <table class="table table-bordered table-sm" aria-label="Table describing statistic about your votes, including votes distribution">
+    <thead>
+      <tr>
+        <th scope="col" style="width: 260px">Grouping</th>
+        <th scope="col" style="width: 170px">Reviews count (+ abst)</th>
+        <th scope="col" style="width: 90px">Median</th>
+        <th scope="col" style="width: 150px">Mean (std deviation)</th>
+        <th scope="col" style="width: 160px">Most frequent (count)</th>
+        <th scope="col">Distribution</th>
+      </tr>
+    </thead>
+    <tbody>
+      @reviewerStats.map { reviewerStat =>
+        <tr>
+          <td>@Messages(reviewerStat.labelKey)</td>
+          <td>@reviewerStat.count (+@{reviewerStat.countIncludingAbstentions-reviewerStat.count})</td>
+          <td>@reviewerStat.median.toInt</td>
+          <td>@views.html.tags.toScaled(reviewerStat.mean, 3) (@views.html.tags.toScaled(reviewerStat.stdDeviation, 3))</td>
+          <td>
+            @{if(reviewerStat.mode.toInt==0){ Messages("Abs") } else { reviewerStat.mode.toInt }}
+            (@reviewerStat.perVoteCount.get(reviewerStat.mode.toInt).getOrElse(0))
+          <td>
+            <div style="width: 400px; height: 100px;">
+            @views.html.tags.scoreBarChart(reviewerStat.perVoteCount.map { case (vote, count) =>
+              (vote, count)
+            }.toList.sortBy(_._1))
+            </div>
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+}.getOrElse {
+  No reviews made yet !
+}

--- a/app/views/tags/scoreBarChart.scala.html
+++ b/app/views/tags/scoreBarChart.scala.html
@@ -1,0 +1,23 @@
+@(
+    values: List[(Int,Int)]
+)(implicit lang: Lang)
+
+<div style="display: grid;
+  grid-template-columns: repeat(@values.length, 1fr);
+  grid-template-rows: repeat(101, 1fr);
+  grid-column-gap: 5px;
+  height: 90%;
+  width: 100%;
+  padding: 5px 10px;
+  ">
+@TemplateMagic.defining(values.maxBy(_._2)._2) { maxCount =>
+  @values.map { case(vote, count) =>
+  <div data-score="@vote" class="bar-score" style="
+    border-radius: 5px 5px 0 0;
+    transition: all .6s ease;
+    grid-row-end: 102;
+    grid-row-start: @{101-Math.round(count*100/maxCount)}
+    "></div>
+  }
+}
+</div>

--- a/app/views/tags/scoreBarChart.scala.html
+++ b/app/views/tags/scoreBarChart.scala.html
@@ -2,22 +2,13 @@
     values: List[(Int,Int)]
 )(implicit lang: Lang)
 
-<div style="display: grid;
-  grid-template-columns: repeat(@values.length, 1fr);
-  grid-template-rows: repeat(101, 1fr);
-  grid-column-gap: 5px;
-  height: 90%;
-  width: 100%;
-  padding: 5px 10px;
-  ">
+<div class="score-bar-chart" style="grid-template-columns: repeat(@values.length, 1fr); grid-template-rows: repeat(101, 1fr);">
 @TemplateMagic.defining(values.maxBy(_._2)._2) { maxCount =>
   @values.map { case(vote, count) =>
-  <div data-score="@vote" class="bar-score" style="
-    border-radius: 5px 5px 0 0;
-    transition: all .6s ease;
-    grid-row-end: 102;
-    grid-row-start: @{101-Math.round(count*100/maxCount)}
-    "></div>
+    <div data-score="@vote" class="bar-score"
+      style="grid-row-end: 102; grid-row-start: @{101-Math.round(count*100/maxCount)}"
+      title="@{if(vote==0){Messages("Abs")}else{vote}}">
+    </div>
   }
 }
 </div>

--- a/app/views/tags/toScaled.scala.html
+++ b/app/views/tags/toScaled.scala.html
@@ -1,0 +1,2 @@
+@(value: Double, scale: Int = 2)
+@BigDecimal(value).setScale(scale,scala.math.BigDecimal.RoundingMode.HALF_EVEN).toDouble

--- a/conf/messages
+++ b/conf/messages
@@ -276,6 +276,8 @@ track.geek.desc=All about the future of work and how to stay ahead of the curve.
 geek.label=People & Culture, Soft Skills, Future of work, Innovation, Geek Life
 geek.leaderboard=People & Culture
 
+track.all.title=All
+
 # confirm import
 confirm.import.title=Create your Speaker''s profile
 confirm.import.save=Save and send an email

--- a/conf/messages.fr
+++ b/conf/messages.fr
@@ -214,6 +214,8 @@ track.lang.desc=Kotlin, Rust, Scala, Go, TypeScript, Javascript, Clojure, Haskel
 lang.label=Langages
 lang.leaderboard=Langages
 
+track.all.title=Toutes
+
 # Confirm import
 confirm.import.title=Créer votre profil de présentateur Devoxx France
 confirm.import.save=Enregistrer et continuer


### PR DESCRIPTION
This PR brings some statistics (count, median, mean, stddev and distribution) on MyVotes screens (on both CFP comitee and GT)

<img width="1332" alt="Cursor_and_All_my_votes_-_Devoxx_France_2023" src="https://user-images.githubusercontent.com/603815/202930194-42491b58-a2cc-4397-a7eb-1a9367802619.png">

Note that I took advantage of this PR to remove every `table-condensed` class usages, as it was renamed to `table-sm` in bootstrap 4 (see [here](https://getbootstrap.com/docs/4.0/migration/#tables))