### PR TITLE
Track stats during deliberation

### DIFF
--- a/app/controllers/ApproveOrRefuse.scala
+++ b/app/controllers/ApproveOrRefuse.scala
@@ -24,6 +24,7 @@
 package controllers
 
 
+import controllers.Favorites.{JSON, Ok}
 import library._
 import models.Review._
 import models._
@@ -40,53 +41,53 @@ import scala.concurrent.Future
   */
 object ApproveOrRefuse extends SecureCFPController {
 
-  def doApprove(proposalId: String) = SecuredAction(IsMemberOf("cfp")).async {
+  def doApprove(proposalId: String) = SecuredAction(IsMemberOf("cfp")) {
     implicit request: SecuredRequest[play.api.mvc.AnyContent] =>
       Proposal.findById(proposalId).map {
         proposal =>
           ApprovedProposal.approve(proposal)
           Event.storeEvent(ApprovedProposalEvent(request.webuser.uuid, proposalId, proposal.title, proposal.talkType.id, proposal.track.id))
-          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id)).flashing("success" -> s"Talk ${proposal.id} has been accepted."))
+          Ok("{\"status\":\"ok\"}").as(JSON)
       }.getOrElse {
-        Future.successful(Redirect(routes.CFPAdmin.allVotes()).flashing("error" -> "Talk not found"))
+        NotFound("{\"status\":\"not_found\"}").as(JSON)
       }
   }
 
-  def doRefuse(proposalId: String) = SecuredAction(IsMemberOf("cfp")).async {
+  def doRefuse(proposalId: String) = SecuredAction(IsMemberOf("cfp")) {
     implicit request: SecuredRequest[play.api.mvc.AnyContent] =>
       Proposal.findById(proposalId).map {
         proposal =>
           ApprovedProposal.refuse(proposal)
           Event.storeEvent(TalkRefusedEvent(request.webuser.uuid, proposalId, proposal.title, proposal.talkType.id, proposal.track.id))
-          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id)).flashing("success" -> s"Talk ${proposal.id} has been refused."))
+          Ok("{\"status\":\"ok\"}").as(JSON)
       }.getOrElse {
-        Future.successful(Redirect(routes.CFPAdmin.allVotes()).flashing("error" -> "Talk not found"))
+        NotFound("{\"status\":\"not_found\"}").as(JSON)
       }
   }
 
-  def cancelApprove(proposalId: String) = SecuredAction(IsMemberOf("cfp")).async {
+  def cancelApprove(proposalId: String) = SecuredAction(IsMemberOf("cfp")) {
     implicit request: SecuredRequest[play.api.mvc.AnyContent] =>
       Proposal.findById(proposalId).map {
         proposal =>
           val confType: String = proposal.talkType.id
           ApprovedProposal.cancelApprove(proposal)
           Event.storeEvent(TalkRemovedFromApprovedListEvent(request.webuser.uuid, proposalId, proposal.title, proposal.talkType.id, proposal.track.id))
-          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id, confType)).flashing("success" -> s"Talk ${proposal.id} has been removed from Approved list."))
+          Ok("{\"status\":\"ok\"}").as(JSON)
       }.getOrElse {
-        Future.successful(Redirect(routes.CFPAdmin.allVotes()).flashing("error" -> "Talk not found"))
+        NotFound("{\"status\":\"not_found\"}").as(JSON)
       }
   }
 
-  def cancelRefuse(proposalId: String) = SecuredAction(IsMemberOf("cfp")).async {
+  def cancelRefuse(proposalId: String) = SecuredAction(IsMemberOf("cfp")) {
     implicit request: SecuredRequest[play.api.mvc.AnyContent] =>
       Proposal.findById(proposalId).map {
         proposal =>
           val confType: String = proposal.talkType.id
           ApprovedProposal.cancelRefuse(proposal)
           Event.storeEvent(TalkRemovedFromRefuseListEvent(request.webuser.uuid, proposalId, proposal.title, proposal.talkType.id, proposal.track.id))
-          Future.successful(Redirect(routes.CFPAdmin.allVotes(proposal.talkType.id, confType)).flashing("success" -> s"Talk ${proposal.id} has been removed from Refused list."))
+          Ok("{\"status\":\"ok\"}").as(JSON)
       }.getOrElse {
-        Future.successful(Redirect(routes.CFPAdmin.allVotes()).flashing("error" -> "Talk not found"))
+        NotFound("{\"status\":\"not_found\"}").as(JSON)
       }
   }
 

--- a/app/controllers/CFPAdmin.scala
+++ b/app/controllers/CFPAdmin.scala
@@ -738,7 +738,7 @@ object CFPAdmin extends SecureCFPController {
             }
           }
           (company, setOfProposals)
-      }
+      }.sortBy(_._2.size).reverse
 
       Ok(views.html.CFPAdmin.allApprovedSpeakersByCompany(speakers, proposals))
   }

--- a/app/views/CFPAdmin/allSpeakers.scala.html
+++ b/app/views/CFPAdmin/allSpeakers.scala.html
@@ -42,10 +42,10 @@
                 <thead>
                     <tr>
                         <th scope="row">Name</th>
-                        <th scope="row">Lang</th>
                         <th scope="row">Company</th>
                         <th scope="row">Email</th>
-                        <th scope="row">Total Approved</th>
+                        <th scope="row">Total Approved (BoF excluded)</th>
+                        <th scope="row">Approved Types</th>
                         <th scope="row">Total Accepted</th>
                         <th scope="row">Submitted Talks</th>
                     </tr>
@@ -53,11 +53,8 @@
                 <tbody>
                 @speakers.map { case (speaker: Speaker, proposals) =>
                     <tr>
-                       <td>
-                            @tags.renderGravatar(speaker.uuid, showName=true, showPhoto=false)
-                       </td>
                         <td>
-                            @speaker.cleanLang
+                            @tags.renderGravatar(speaker.uuid, showName=true, showPhoto=false) <small>(@speaker.cleanLang)</small>
                         </td>
                         <td>
                             @speaker.company.getOrElse("")
@@ -66,9 +63,16 @@
                             <small>@speaker.email</small>
                         </td>
                         <td>
-                            @allApprovedProposalIDs.count(proposalID => proposals.contains(proposalID))
+                            @allApprovedProposalIDs.count(proposalID => proposals.contains(proposalID) && proposals.get(proposalID).get.talkType.id != ConferenceDescriptor.ConferenceProposalTypes.BOF.id)
                         </td>
-                        <td>@proposals.values.count(proposal => ApprovedProposal.isAccepted(proposal.id))</td>
+                        <td>
+                            @for((talkType: String, proposalIds: Set[String]) <- allApprovedProposalIDs.filter(proposalID => proposals.contains(proposalID)).groupBy{ proposalID => proposals.get(proposalID).get.talkType.id }) {
+                                <span class="badge badge-info">@talkType : @proposalIds.size</span>
+                            }
+                        </td>
+                        <td>
+                            @proposals.values.count(proposal => ApprovedProposal.isAccepted(proposal.id))
+                        </td>
 
                         <td>
                         @proposals.values.map { proposal: Proposal =>
@@ -82,6 +86,7 @@
                             <strong>@Messages(proposal.talkType.simpleLabel)</strong>
                             &nbsp;
                             <a href="@routes.CFPAdmin.openForReview(proposal.id)" title="@proposal.title" target="_blank">@proposal.title</a>
+                            (@proposal.allSpeakers.size @if(proposal.allSpeakers.size>1){ speakers } else { speaker })
                             </div>
                         }
                         </td>

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -249,7 +249,7 @@
                         e.preventDefault();
                         var url = this.href;
                         var link = $(this);
-                        var trTable = $(this).parent().parent();
+                        var trTable = $(this).parents('tr');
                         link.addClass("loading");
                         $.get(url, function () {
                             link.removeClass("loading");
@@ -265,7 +265,7 @@
                         e.preventDefault();
                         var url = this.href;
                         var link = $(this);
-                        var trTable = $(this).parent().parent();
+                        var trTable = $(this).parents('tr');
                         link.addClass("loading");
                         $.get(url, function () {
                             link.removeClass("loading");
@@ -281,7 +281,7 @@
                         e.preventDefault();
                         var url = this.href;
                         var link = $(this);
-                        var trTable = $(this).parent().parent();
+                        var trTable = $(this).parents('tr');
                         link.addClass("loading");
                         $.get(url, function () {
                             link.removeClass("loading");
@@ -298,7 +298,7 @@
                         var url = this.href;
                         var link = $(this);
                         link.addClass("loading");
-                        var trTable = $(this).parent().parent();
+                        var trTable = $(this).parents('tr');
                         $.get(url, function () {
                             link.removeClass("loading");
                             link.addClass("sent");

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -81,7 +81,8 @@
                 <br>
                 <span class="badge badge-primary">@allVotes.map(_._1).count(_.lang == "fr")
                     FR</span> <span class="badge badge-secondary">@allVotes.map(_._1).count(_.lang == "en") EN</span>
-
+                <br/>
+                <span class="badge badge-pill badge-@ProposalState.ACCEPTED.code">@ProposalState.ACCEPTED.code</span> <small><strong>proposals (and above)</strong>:</small> <span id="acceptedTalksStats"></span>
             </div>
         </div>
         <div class="row">
@@ -104,7 +105,7 @@
                             <th>Speakers</th>
                             <th class="prop-track-col">Track</th>
                             <th class="prop-type-col">Type</th>
-                            <th>Lang</th>
+                            <th class="prop-lang-col">Lang</th>
                             <th><i class="fas fa-thumbs-up"></i> / <i class="fas fa-thumbs-down"></i></th>
                             <th class="hidden">Summary</th>
                         </tr>
@@ -180,7 +181,7 @@
                                     <td class="prop-type-col">
                                         <small>@proposal.talkType.id</small>
                                     </td>
-                                    <td>
+                                    <td class="prop-lang-col">
                                         [@proposal.lang]
                                     </td>
                                     <td>
@@ -272,6 +273,7 @@
                             link.addClass("sent");
                             trTable.removeClass("preselected_false refused_false");
                             trTable.addClass("preselected_true refused_false");
+                            refreshAcceptedTalksPerTrack();
                         }).fail(function () {
                             alert("error");
                         });
@@ -288,6 +290,7 @@
                             link.addClass("sent");
                             trTable.removeClass("preselected_true refused_false");
                             trTable.addClass("preselected_false refused_false");
+                            refreshAcceptedTalksPerTrack();
                         }).fail(function () {
                             alert("error");
                         });
@@ -327,6 +330,34 @@
                 function showGTVotes(show) { changeColumnsVisibility([2,5], show, "showGTVotes"); }
                 function showProposalType(show) { changeColumnsVisibility([10], show); }
                 function showTrack(show) { changeColumnsVisibility([9], show); }
+
+                function refreshAcceptedTalksPerTrack() {
+                    const acceptedProposalsTotal = $(".preselected_true").length
+                    const acceptedProposalsCounts = $(".preselected_true").map((idx,el) => ({
+                            track: $(el).find(".prop-track-col").text().trim(),
+                            lang: $(el).find(".prop-lang-col").text().trim(),
+                        })).toArray()
+                        .reduce((result, props) => {
+                            result.perTrack[props.track] = result.perTrack[props.track] || 0;
+                            result.perTrack[props.track]++;
+
+                            result.perLang[props.lang] = result.perLang[props.lang] || 0;
+                            result.perLang[props.lang]++;
+
+                            return result;
+                        }, { perTrack: {}, perLang: {}})
+
+                    $("#acceptedTalksStats").html(
+                        Object.entries(acceptedProposalsCounts.perTrack).sort(([_, count1], [_2, count2]) => count2-count1)
+                            .map(([track, count]) => `<span class="badge badge-info">${track}: ${count} (${Math.round(count*100/acceptedProposalsTotal)}%)</span>`)
+                            .join(" ")
+                        +" "
+                        +Object.entries(acceptedProposalsCounts.perLang).sort(([_, count1], [_2, count2]) => count2-count1)
+                            .map(([lang, count]) => `<span class="badge badge-warning">${lang}: ${count} (${Math.round(count*100/acceptedProposalsTotal)}%)</span>`)
+                            .join(" ")
+                    );
+                }
+                refreshAcceptedTalksPerTrack();
         </script>
         }
     }

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -79,8 +79,12 @@
                     - @declinedTotal declined</span> <span class="badge badge-warning">
                     = @remainingIncludingDeclined remaining</span>
                 <br>
-                <span class="badge badge-primary">@allVotes.map(_._1).count(_.lang == "fr")
-                    FR</span> <span class="badge badge-secondary">@allVotes.map(_._1).count(_.lang == "en") EN</span>
+                <small><strong>All proposals</strong></small>:
+                    @for((trackLabel: String, proposals: List[Proposal]) <- allVotes.map(_._1).groupBy{ proposal => Messages(proposal.track.label) }.toList.sortBy(-_._2.size)) {
+                        <span class="badge badge-info">@trackLabel: @proposals.size (@{(proposals.size.toFloat*100/allVotes.size).round}%)</span>
+                    }
+                    <span class="badge badge-warning">[fr]: @allVotes.map(_._1).count(_.lang == "fr") (@{(allVotes.map(_._1).count(_.lang == "fr").toFloat*100/allVotes.size).round}%)</span>
+                    <span class="badge badge-warning">[en]: @allVotes.map(_._1).count(_.lang == "en") (@{(allVotes.map(_._1).count(_.lang == "en").toFloat*100/allVotes.size).round}%)</span>
                 <br/>
                 <span class="badge badge-pill badge-@ProposalState.ACCEPTED.code">@ProposalState.ACCEPTED.code</span> <small><strong>proposals (and above)</strong>:</small> <span id="acceptedTalksStats"></span>
             </div>


### PR DESCRIPTION
This PR brings some improvements for the deliberation meetings that are going to take place next week.

# All Votes screen

- Performance has been improved whenever we approve/reject a proposal (a 303 redirect on allVotes was returned by the XHR call ... which was taking a long time to render for nothing)
- We had a UI bug when a proposal was approved/rejected : only the cell with buttons was having its background changed. Now, the whole line's background is updated
- We now display a tracks & langs count for every accepted talks currently displayed. Important note : to make it work, "Show tracks" needs to be checked.

<img width="1509" alt="Cursor_and_All_votes_-_Devoxx_France_2023" src="https://user-images.githubusercontent.com/603815/212794588-c6fddfad-e084-4ddf-accc-cb6ca497241a.png">

# All speakers listing

- BOF are now excluded from accepted talk counts
- Accepted talk type counts are displayed
- Speaker counts are displayed next to every talks (to give an idea on the number of speakers)

<img width="1133" alt="Cursor_and_CFP_Speakers_-_Devoxx_France_2023" src="https://user-images.githubusercontent.com/603815/212794993-bc0a23f1-31e5-4085-9f6a-14ec90f86a5d.png">

# Approved Talks by company

Companies are now sorted by talks count (previously, it was sorted pseudo randomly)
