### PR TITLE
Allow refresh of remaining/accepted talks on clientside

### DIFF
--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -75,10 +75,18 @@
                 }
             </div>
             <div class="col-md-12 mt-2">
+                <small><strong>Serverside overall stats</strong></small> :
                 <span class="badge badge-success">@totalApproved approved</span> <span class="badge badge-declined">
                     - @declinedTotal declined</span> <span class="badge badge-warning">
                     = @remainingIncludingDeclined remaining</span>
                 <br>
+                @if(selectedTrack=="all") {
+                    <small><strong>Clientside overall stats</strong></small> :
+                    <span class="badge badge-success"><span id="totalAcceptedProposals"></span> approved</span> <span class="badge badge-declined">
+                        - <span id="totalDeclinedProposals"></span> declined</span> <span class="badge badge-warning">
+                        = <span id="totalRemainingProposals"></span> remaining</span>
+                    <br/>
+                }
                 <small><strong>All proposals</strong></small>:
                     @for((trackLabel: String, proposals: List[Proposal]) <- allVotes.map(_._1).groupBy{ proposal => Messages(proposal.track.label) }.toList.sortBy(-_._2.size)) {
                         <span class="badge badge-info">@trackLabel: @proposals.size (@{(proposals.size.toFloat*100/allVotes.size).round}%)</span>
@@ -189,7 +197,7 @@
                                         [@proposal.lang]
                                     </td>
                                     <td>
-                                        <div class="btn-group" role="group">
+                                        <div class="btn-group" role="group" data-state="@proposal.state.code">
                                             @if(approved) {
                                                 <a href="@routes.ApproveOrRefuse.cancelApprove(proposal.id)" class="cancelAcceptBtn btn btn-danger" title="Cancel Pre-Approve"><i class="fas fa-undo"></i></a>
                                             }
@@ -348,8 +356,10 @@
                             result.perLang[props.lang] = result.perLang[props.lang] || 0;
                             result.perLang[props.lang]++;
 
+                            result.total++;
+
                             return result;
-                        }, { perTrack: {}, perLang: {}})
+                        }, { perTrack: {}, perLang: {}, total: 0})
 
                     $("#acceptedTalksStats").html(
                         Object.entries(acceptedProposalsCounts.perTrack).sort(([_, count1], [_2, count2]) => count2-count1)
@@ -360,6 +370,12 @@
                             .map(([lang, count]) => `<span class="badge badge-warning">${lang}: ${count} (${Math.round(count*100/acceptedProposalsTotal)}%)</span>`)
                             .join(" ")
                     );
+
+                    const slotsCount = @{ConferenceDescriptor.ConferenceProposalConfigurations.parse(confType).slotsCount};
+                    const declinedTalks = $("[data-state='declined']").length;
+                    $("#totalAcceptedProposals").html(acceptedProposalsCounts.total)
+                    $("#totalDeclinedProposals").html(declinedTalks)
+                    $("#totalRemainingProposals").html(slotsCount - acceptedProposalsCounts.total + declinedTalks)
                 }
                 refreshAcceptedTalksPerTrack();
         </script>


### PR DESCRIPTION
Add a new line for approved/declined/remaining stat on all votes screen, in order to calculate these stats on clientside (without refresh)

I kept the serverside computation just in case there may be a regression (I tested the computation locally, even with `declined` talks, but in case I missed something...)

<img width="1177" alt="Cursor_and_All_votes_-_Devoxx_France_2023" src="https://user-images.githubusercontent.com/603815/214151622-ab13f21f-673a-45be-a36a-f0abe0d507d7.png">

