### PR TITLE
Multiple allvotes screen enhancements

### DIFF
--- a/app/assets/css/cfp.less
+++ b/app/assets/css/cfp.less
@@ -173,11 +173,23 @@ table#allProposals.dataTable.display tbody tr>.sorting_3 {
   background-color: rgba(0,0,0,0.1)
 }
 
-.preselected_true {
+[data-external-state='accepted'], [data-internal-state='accepted'] {
   background-color: #fff8ba !important; // Attention dataTable vire le background pour mettre son bleu
   border-style: solid;
   border-width: 2px;
   border-color: #fff8ba;
+}
+
+.cancelAcceptBtn, .preApprovedTag { display: none; }
+[data-external-state='submitted'][data-internal-state='accepted'] .cancelAcceptBtn,
+[data-external-state='submitted'][data-internal-state='accepted'] .preApprovedTag {
+  display: block;
+}
+
+.approveBtn, .refuseBtn { display: none; }
+[data-external-state='submitted'][data-internal-state='submitted'] .approveBtn,
+[data-external-state='submitted'][data-internal-state='submitted'] .refuseBtn {
+  display: block;
 }
 
 .average_table {
@@ -348,8 +360,15 @@ a.badge-declined:focus, a.badge-declined.focus {
   font-style: italic;
 }
 
-.refused_true {
+[data-external-state='rejected'],
+[data-internal-state='rejected'] {
   background-color: #ffc1a6 !important;
+}
+
+.cancelRefuseBtn, .preRefusedTag { display: none; }
+[data-external-state='submitted'][data-internal-state='rejected'] .cancelRefuseBtn,
+[data-external-state='submitted'][data-internal-state='rejected'] .preRefusedTag {
+  display: block;
 }
 
 #antispam_field {

--- a/app/assets/css/cfp.less
+++ b/app/assets/css/cfp.less
@@ -1021,3 +1021,18 @@ hr.borderless {
 .dvx_2023{
   background-color: #e8a262;
 }
+
+.sticky {
+  position: fixed;
+  top: 0px;
+  margin-top: 0px;
+  z-index: 10;
+  background-color: white;
+  width: 100%;
+  left: 0px;
+  padding-right: 30px;
+  padding-left: 30px;
+
+  border-bottom: 3px solid black;
+  padding-bottom: 5px;
+}

--- a/app/controllers/GoldenTicketAdminController.scala
+++ b/app/controllers/GoldenTicketAdminController.scala
@@ -173,7 +173,12 @@ object GoldenTicketAdminController extends SecureCFPController {
           proposal.state == ProposalState.DRAFT || proposal.state == ProposalState.ARCHIVED || proposal.state == ProposalState.DELETED || proposal.state == ProposalState.CANCELLED
       }.sortBy(_._2._4.n).reverse
 
-      Ok(views.html.GoldenTicketAdmin.showGoldenTicketVotes(listOfProposals))
+      val proposalIdsToDisplay = listOfProposals.map { case (proposal, _) => proposal.id }.toSet
+
+      val allApprovedProposalIds = ApprovedProposal.allApprovedProposalIDs().filter { proposalId => proposalIdsToDisplay.contains(proposalId) }
+      val allRejectedProposalIds = ApprovedProposal.allRefusedProposalIDs().filter { proposalId => proposalIdsToDisplay.contains(proposalId) }
+
+      Ok(views.html.GoldenTicketAdmin.showGoldenTicketVotes(listOfProposals, allApprovedProposalIds, allRejectedProposalIds))
   }
 
   def repairStatsAfterGTArchivingAction() = SecuredAction(IsMemberOf("admin")) {

--- a/app/views/Backoffice/allProposals.scala.html
+++ b/app/views/Backoffice/allProposals.scala.html
@@ -1,4 +1,4 @@
-@(proposals:List[Proposal], filterByStatus:Option[String])(implicit lang: Lang, flash: Flash, req:RequestHeader)
+@(proposals:List[Proposal], allApprovedProposalIds: Set[String], allRejectedProposalIds: Set[String], filterByStatus:Option[String])(implicit lang: Lang, flash: Flash, req:RequestHeader)
 
 @main("CFP Admin - all talks") {
 
@@ -58,9 +58,7 @@
                 </thead>
                 <tbody>
                 @proposals.map{ proposal =>
-                    @defining(ApprovedProposal.isRefused(proposal.id, proposal.talkType.id)) { refused =>
-                        @defining(ApprovedProposal.isApproved(proposal.id, proposal.talkType.id)) { approved =>
-                            <tr class="preselected_@approved refused_@refused">
+                            <tr data-external-state="@proposal.state.code" data-internal-state="@if(allApprovedProposalIds.contains(proposal.id)){accepted}else{@if(allRejectedProposalIds.contains(proposal.id)){rejected}else{submitted}}">
                                 <td>
                                     <small><a href="@routes.CFPAdmin.openForReview(proposal.id)">@proposal.id</a></small>
                                 </td>
@@ -91,8 +89,6 @@
 
                                 </td>
                             </tr>
-                        }
-                    }
                 }
                 </tbody>
             </table>

--- a/app/views/Backoffice/showAllDeclined.scala.html
+++ b/app/views/Backoffice/showAllDeclined.scala.html
@@ -1,4 +1,4 @@
-@(proposals:List[Proposal])(implicit lang: Lang, flash: Flash, req:RequestHeader)
+@(proposals:List[Proposal], allApprovedProposalIds: Set[String], allRejectedProposalIds: Set[String])(implicit lang: Lang, flash: Flash, req:RequestHeader)
 
 @main("CFP Admin - all declined") {
 
@@ -45,9 +45,7 @@
                 </thead>
                 <tbody>
                 @proposals.map{ proposal =>
-                    @defining(ApprovedProposal.isRefused(proposal.id, proposal.talkType.id)) { refused =>
-                        @defining(ApprovedProposal.isApproved(proposal.id, proposal.talkType.id)) { approved =>
-                            <tr class="preselected_@approved refused_@refused">
+                            <tr data-external-state="@proposal.state.code" data-internal-state="@if(allApprovedProposalIds.contains(proposal.id)){accepted}else{@if(allRejectedProposalIds.contains(proposal.id)){rejected}else{submitted}}">
                                 <td>
                                     <small><a href="@routes.CFPAdmin.openForReview(proposal.id)">@proposal.id</a></small>
                                 </td>
@@ -69,8 +67,6 @@
                                         Backup</a> </small>
                                 </td>
                             </tr>
-                        }
-                    }
                 }
                 </tbody>
             </table>

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -75,10 +75,18 @@
                 }
             </div>
             <div class="col-md-12 mt-2" id="sticky-header">
+                <small><strong>Serverside overall stats</strong></small> :
                 <span class="badge badge-success">@allApprovedProposalIds.size approved</span> <span class="badge badge-declined">
                     - @declinedTotal declined</span> <span class="badge badge-warning">
                     = @remainingIncludingDeclined remaining</span>
                 <br>
+                @if(selectedTrack=="all") {
+                    <small><strong>Clientside overall stats</strong></small> :
+                    <span class="badge badge-success"><span id="totalAcceptedProposals"></span> approved</span> <span class="badge badge-declined">
+                        - <span id="totalDeclinedProposals"></span> declined</span> <span class="badge badge-warning">
+                        = <span id="totalRemainingProposals"></span> remaining</span>
+                    <br/>
+                }
                 <small><strong>All proposals</strong></small>:
                     @for((trackLabel: String, proposals: List[Proposal]) <- allVotes.map(_._1).groupBy{ proposal => Messages(proposal.track.label) }.toList.sortBy(-_._2.size)) {
                         <span class="badge badge-info">@trackLabel: @proposals.size (@{(proposals.size.toFloat*100/allVotes.size).round}%)</span>
@@ -191,7 +199,7 @@
                                         [@proposal.lang]
                                     </td>
                                     <td>
-                                        <div class="btn-group" role="group">
+                                        <div class="btn-group" role="group" data-state="@proposal.state.code">
                                             <button data-action-url="@routes.ApproveOrRefuse.cancelApprove(proposal.id)" class="cancelAcceptBtn btn btn-danger" title="Cancel Pre-Approve"><i class="fas fa-undo"></i></button>
                                             <button data-action-url="@routes.ApproveOrRefuse.cancelRefuse(proposal.id)" class="cancelRefuseBtn btn btn-danger" title="Cancel Pre-Refuse"><i class="fas fa-undo"></i></button>
                                             <button data-action-url="@routes.ApproveOrRefuse.doApprove(proposal.id)" class="approveBtn btn btn-success" title="Pre-Approve"><i class="fas fa-thumbs-up"></i></button>
@@ -348,8 +356,8 @@
                 function showTrack(show) { changeColumnsVisibility([9], show); }
 
                 function refreshAcceptedTalksPerTrack() {
-                    const acceptedProposalsTotal = $(".preselected_true").length
-                    const acceptedProposalsCounts = $(".preselected_true").map((idx,el) => ({
+                    const acceptedProposalsTotal = $("[data-internal-state='accepted']").length
+                    const acceptedProposalsCounts = $("[data-internal-state='accepted']").map((idx,el) => ({
                             track: $(el).find(".prop-track-col").text().trim(),
                             lang: $(el).find(".prop-lang-col").text().trim(),
                         })).toArray()
@@ -360,8 +368,10 @@
                             result.perLang[props.lang] = result.perLang[props.lang] || 0;
                             result.perLang[props.lang]++;
 
+                            result.total++;
+
                             return result;
-                        }, { perTrack: {}, perLang: {}})
+                        }, { perTrack: {}, perLang: {}, total: 0})
 
                     $("#acceptedTalksStats").html(
                         Object.entries(acceptedProposalsCounts.perTrack).sort(([_, count1], [_2, count2]) => count2-count1)
@@ -377,6 +387,12 @@
                     Object.entries(acceptedProposalIdsPerSpeakerId).forEach( ([speakerUUID, acceptedProposalIds]) => {
                         $(`[data-speaker-id='${speakerUUID}'].totalAccepted`).text(acceptedProposalIds.length?`[${acceptedProposalIds.length}]`:'')
                     })
+
+                    const slotsCount = @{ConferenceDescriptor.ConferenceProposalConfigurations.parse(confType).slotsCount};
+                    const declinedTalks = $("[data-state='declined']").length;
+                    $("#totalAcceptedProposals").html(acceptedProposalsCounts.total)
+                    $("#totalDeclinedProposals").html(declinedTalks)
+                    $("#totalRemainingProposals").html(slotsCount - acceptedProposalsCounts.total + declinedTalks)
                 }
                 refreshAcceptedTalksPerTrack();
 

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -1,4 +1,4 @@
-@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long, Double, Option[Double])], totalApproved: Long, totalRemaining: Long, confType: String, selectedTrack: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
+@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long, Double, Option[Double])], allApprovedProposalIds: Set[String], allRejectedProposalIds: Set[String], totalRemaining: Long, confType: String, selectedTrack: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
     @import models.Review.{AverageNote, TotalAbst, TotalVoter}
 
     @main("All votes") {
@@ -75,7 +75,7 @@
                 }
             </div>
             <div class="col-md-12 mt-2">
-                <span class="badge badge-success">@totalApproved approved</span> <span class="badge badge-declined">
+                <span class="badge badge-success">@allApprovedProposalIds.size approved</span> <span class="badge badge-declined">
                     - @declinedTotal declined</span> <span class="badge badge-warning">
                     = @remainingIncludingDeclined remaining</span>
                 <br>
@@ -116,9 +116,7 @@
                     </thead>
                     <tbody>
                     @allVotes.sortBy(-_._2._4.n).zipWithIndex.map { case ((proposal, voteAndTotalVotes, gtScore, gtVoteCast, gtAndComiteeScore, maybeMyVote), index) =>
-                        @defining(ApprovedProposal.isRefused(proposal.id, proposal.talkType.id)) { refused =>
-                            @defining(ApprovedProposal.isApproved(proposal.id, proposal.talkType.id)) { approved =>
-                                <tr class="preselected_@approved refused_@refused">
+                                <tr data-proposal-id="@proposal.id" data-external-state="@proposal.state.code" data-internal-state="@if(allApprovedProposalIds.contains(proposal.id)){accepted}else{@if(allRejectedProposalIds.contains(proposal.id)){rejected}else{submitted}}">
                                     <td class="number_table">@{index+1}</td>
                                     <td class="average_table">
                                     @defining(voteAndTotalVotes._4) { average: AverageNote =>
@@ -190,28 +188,20 @@
                                     </td>
                                     <td>
                                         <div class="btn-group" role="group">
-                                            @if(approved) {
-                                                <button data-action-url="@routes.ApproveOrRefuse.cancelApprove(proposal.id)" class="cancelAcceptBtn btn btn-danger" title="Cancel Pre-Approve"><i class="fas fa-undo"></i></button>
-                                            }
-                                            @if(refused) {
-                                                <button data-action-url="@routes.ApproveOrRefuse.cancelRefuse(proposal.id)" class="cancelRefuseBtn btn btn-danger" title="Cancel Pre-Refuse"><i class="fas fa-undo"></i></button>
-                                            }
-                                            @if(!approved && !refused) {
-                                                <button data-action-url="@routes.ApproveOrRefuse.doApprove(proposal.id)" class="approveBtn btn btn-success" title="Pre-Approve"><i class="fas fa-thumbs-up"></i></button>
-                                                <button data-action-url="@routes.ApproveOrRefuse.doRefuse(proposal.id)" class="refuseBtn btn btn-danger" title="Pre-Refuse"><i class="fas fa-thumbs-down"></i></button>
-                                            }
+                                            <button data-action-url="@routes.ApproveOrRefuse.cancelApprove(proposal.id)" class="cancelAcceptBtn btn btn-danger" title="Cancel Pre-Approve"><i class="fas fa-undo"></i></button>
+                                            <button data-action-url="@routes.ApproveOrRefuse.cancelRefuse(proposal.id)" class="cancelRefuseBtn btn btn-danger" title="Cancel Pre-Refuse"><i class="fas fa-undo"></i></button>
+                                            <button data-action-url="@routes.ApproveOrRefuse.doApprove(proposal.id)" class="approveBtn btn btn-success" title="Pre-Approve"><i class="fas fa-thumbs-up"></i></button>
+                                            <button data-action-url="@routes.ApproveOrRefuse.doRefuse(proposal.id)" class="refuseBtn btn btn-danger" title="Pre-Refuse"><i class="fas fa-thumbs-down"></i></button>
                                         </div>
                                         <br>
                                         <span class="badge badge-pill badge-@proposal.state.code">@proposal.state.code</span>
-                                        @if(approved && (proposal.state == ProposalState.SUBMITTED || proposal.state == ProposalState.BACKUP)) {<span class="badge badge-pill badge-success"><i class="fas fa-thumbs-up"></i> pre-approved</span>}
-                                        @if(refused && (proposal.state == ProposalState.SUBMITTED || proposal.state == ProposalState.BACKUP)) {<span class="badge badge-pill badge-danger"><i class="fas fa-thumbs-down"></i> pre-refused</span>}
+                                        <span class="badge badge-pill badge-success preApprovedTag"><i class="fas fa-thumbs-up"></i> pre-approved</span>
+                                        <span class="badge badge-pill badge-danger preRefusedTag"><i class="fas fa-thumbs-down"></i> pre-refused</span>
                                     </td>
                                     <td class="hidden">
                                         @Html(proposal.summaryAsHtml)
                                     </td>
                                 </tr>
-                            }
-                        }
                     }
                     </tbody>
                 </table>
@@ -254,12 +244,12 @@
                         var url = this.dataset['actionUrl'];
                         var link = $(this);
                         var trTable = $(this).parents('tr');
+
                         link.addClass("loading");
                         $.get(url, function () {
                             link.removeClass("loading");
-                            link.addClass("sent");
-                            trTable.removeClass("preselected_false refused_false");
-                            trTable.addClass("preselected_false refused_true");
+
+                            trTable.attr('data-internal-state', 'rejected')
                         }).fail(function () {
                             alert("error");
                         });
@@ -272,9 +262,9 @@
                         link.addClass("loading");
                         $.get(url, function () {
                             link.removeClass("loading");
-                            link.addClass("sent");
-                            trTable.removeClass("preselected_false refused_false");
-                            trTable.addClass("preselected_true refused_false");
+
+                            trTable.attr('data-internal-state', 'accepted')
+
                             refreshAcceptedTalksPerTrack();
                         }).fail(function () {
                             alert("error");
@@ -285,12 +275,13 @@
                         var url = this.dataset['actionUrl'];
                         var link = $(this);
                         var trTable = $(this).parents('tr');
+
                         link.addClass("loading");
                         $.get(url, function () {
                             link.removeClass("loading");
-                            link.addClass("sent");
-                            trTable.removeClass("preselected_true refused_false");
-                            trTable.addClass("preselected_false refused_false");
+
+                            trTable.attr('data-internal-state', 'submitted')
+
                             refreshAcceptedTalksPerTrack();
                         }).fail(function () {
                             alert("error");
@@ -300,13 +291,13 @@
                     $('.cancelRefuseBtn').click(function (e) {
                         var url = this.dataset['actionUrl'];
                         var link = $(this);
-                        link.addClass("loading");
                         var trTable = $(this).parents('tr');
+
+                        link.addClass("loading");
                         $.get(url, function () {
                             link.removeClass("loading");
-                            link.addClass("sent");
-                            trTable.removeClass("preselected_false refused_true");
-                            trTable.addClass("preselected_false refused_false");
+
+                            trTable.attr('data-internal-state', 'submitted')
                         }).fail(function () {
                             alert("error");
                         });

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -1,4 +1,4 @@
-@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long, Double, Option[Double])], allApprovedProposalIds: Set[String], allRejectedProposalIds: Set[String], totalRemaining: Long, confType: String, selectedTrack: String)(implicit lang: Lang, flash: Flash, req: RequestHeader)
+@(allVotes: List[(models.Proposal, (models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev), Double, Long, Double, Option[Double])], allApprovedProposalIds: Set[String], allRejectedProposalIds: Set[String], totalRemaining: Long, confType: String, selectedTrack: String, acceptedProposalIdsPerSpeakerId: Map[String, Iterable[String]])(implicit lang: Lang, flash: Flash, req: RequestHeader)
     @import models.Review.{AverageNote, TotalAbst, TotalVoter}
 
     @main("All votes") {
@@ -169,11 +169,15 @@
                                     <td>
                                     @proposal.allSpeakers.map { s: Speaker =>
                                         @if(models.Invitation.isInvited(s.uuid)) {
-                                            <span class="badge badge-warning">♥ @s.cleanName <small>
-                                                [@s.company.map(_.toLowerCase.capitalize)]</small></span>
+                                            <span class="badge badge-warning">
+                                                ♥ <span data-speaker-id="@s.uuid" class="totalAccepted"></span> @s.cleanName
+                                                <small>[@s.company.map(_.toLowerCase.capitalize)]</small>
+                                            </span>
                                         } else {
-                                            <span class="badge badge-secondary">@s.cleanName <small>
-                                                [@s.company.map(_.toLowerCase.capitalize)]</small></span>
+                                            <span class="badge badge-secondary">
+                                                <span data-speaker-id="@s.uuid" class="totalAccepted"></span> @s.cleanName
+                                                <small>[@s.company.map(_.toLowerCase.capitalize)]</small>
+                                            </span>
                                         }
                                     }
                                     </td>
@@ -211,6 +215,9 @@
         </div>
 
         <script type="text/javascript">
+                // { [speakerId]: Array<proposalId> }
+                const acceptedProposalIdsPerSpeakerId = @Html(play.api.libs.json.Json.stringify(play.api.libs.json.Json.toJson(acceptedProposalIdsPerSpeakerId)))
+
                 $(document).ready(function () {
 
                     $.fn.dataTableExt.oStdClasses.sStripeOdd = '';
@@ -259,6 +266,15 @@
                         var url = this.dataset['actionUrl'];
                         var link = $(this);
                         var trTable = $(this).parents('tr');
+
+                        const proposalId = trTable.data('proposalId');
+                        const speakerIds = trTable.find("[data-speaker-id]").map((idx, el) => el.dataset['speakerId']).toArray()
+
+                        speakerIds.forEach(speakerId => {
+                            acceptedProposalIdsPerSpeakerId[speakerId] = acceptedProposalIdsPerSpeakerId[speakerId] || [];
+                            acceptedProposalIdsPerSpeakerId[speakerId].push(proposalId);
+                        })
+
                         link.addClass("loading");
                         $.get(url, function () {
                             link.removeClass("loading");
@@ -275,6 +291,15 @@
                         var url = this.dataset['actionUrl'];
                         var link = $(this);
                         var trTable = $(this).parents('tr');
+
+                        const proposalId = trTable.data('proposalId');
+                        const speakerIds = trTable.find("[data-speaker-id]").map((idx, el) => el.dataset['speakerId']).toArray()
+
+                        speakerIds.forEach(speakerId => {
+                            if(acceptedProposalIdsPerSpeakerId[speakerId]) {
+                                acceptedProposalIdsPerSpeakerId[speakerId] = acceptedProposalIdsPerSpeakerId[speakerId].filter(pId => proposalId !== pId);
+                            }
+                        })
 
                         link.addClass("loading");
                         $.get(url, function () {
@@ -347,8 +372,14 @@
                             .map(([lang, count]) => `<span class="badge badge-warning">${lang}: ${count} (${Math.round(count*100/acceptedProposalsTotal)}%)</span>`)
                             .join(" ")
                     );
+
+                    $(".totalAccepted").text('')
+                    Object.entries(acceptedProposalIdsPerSpeakerId).forEach( ([speakerUUID, acceptedProposalIds]) => {
+                        $(`[data-speaker-id='${speakerUUID}'].totalAccepted`).text(acceptedProposalIds.length?`[${acceptedProposalIds.length}]`:'')
+                    })
                 }
                 refreshAcceptedTalksPerTrack();
+
         </script>
         }
     }

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -74,7 +74,7 @@
                     </div>
                 }
             </div>
-            <div class="col-md-12 mt-2">
+            <div class="col-md-12 mt-2" id="sticky-header">
                 <span class="badge badge-success">@allApprovedProposalIds.size approved</span> <span class="badge badge-declined">
                     - @declinedTotal declined</span> <span class="badge badge-warning">
                     = @remainingIncludingDeclined remaining</span>
@@ -380,6 +380,18 @@
                 }
                 refreshAcceptedTalksPerTrack();
 
+                const header = document.querySelector('#sticky-header');
+                const headerOffset = header.offsetTop;
+                function stickyHeader() {
+                    if (window.scrollY >= headerOffset) {
+                        header.classList.add('sticky')
+                        header.classList.remove('mt-2')
+                    } else {
+                        header.classList.remove('sticky');
+                        header.classList.add('mt-2')
+                    }
+                }
+                window.addEventListener('scroll', stickyHeader);
         </script>
         }
     }

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -191,14 +191,14 @@
                                     <td>
                                         <div class="btn-group" role="group">
                                             @if(approved) {
-                                                <a href="@routes.ApproveOrRefuse.cancelApprove(proposal.id)" class="cancelAcceptBtn btn btn-danger" title="Cancel Pre-Approve"><i class="fas fa-undo"></i></a>
+                                                <button data-action-url="@routes.ApproveOrRefuse.cancelApprove(proposal.id)" class="cancelAcceptBtn btn btn-danger" title="Cancel Pre-Approve"><i class="fas fa-undo"></i></button>
                                             }
                                             @if(refused) {
-                                                <a href="@routes.ApproveOrRefuse.cancelRefuse(proposal.id)" class="cancelRefuseBtn btn btn-danger" title="Cancel Pre-Refuse"><i class="fas fa-undo"></i></a>
+                                                <button data-action-url="@routes.ApproveOrRefuse.cancelRefuse(proposal.id)" class="cancelRefuseBtn btn btn-danger" title="Cancel Pre-Refuse"><i class="fas fa-undo"></i></button>
                                             }
                                             @if(!approved && !refused) {
-                                                <a href="@routes.ApproveOrRefuse.doApprove(proposal.id)" class="approveBtn btn btn-success" title="Pre-Approve"><i class="fas fa-thumbs-up"></i></a>
-                                                <a href="@routes.ApproveOrRefuse.doRefuse(proposal.id)" class="refuseBtn btn btn-danger" title="Pre-Refuse"><i class="fas fa-thumbs-down"></i></a>
+                                                <button data-action-url="@routes.ApproveOrRefuse.doApprove(proposal.id)" class="approveBtn btn btn-success" title="Pre-Approve"><i class="fas fa-thumbs-up"></i></button>
+                                                <button data-action-url="@routes.ApproveOrRefuse.doRefuse(proposal.id)" class="refuseBtn btn btn-danger" title="Pre-Refuse"><i class="fas fa-thumbs-down"></i></button>
                                             }
                                         </div>
                                         <br>
@@ -250,9 +250,8 @@
                         "stripeClasses": []
                     });
 
-                    $('a.refuseBtn').click(function (e) {
-                        e.preventDefault();
-                        var url = this.href;
+                    $('.refuseBtn').click(function (e) {
+                        var url = this.dataset['actionUrl'];
                         var link = $(this);
                         var trTable = $(this).parents('tr');
                         link.addClass("loading");
@@ -266,9 +265,8 @@
                         });
                     });
 
-                    $('a.approveBtn').click(function (e) {
-                        e.preventDefault();
-                        var url = this.href;
+                    $('.approveBtn').click(function (e) {
+                        var url = this.dataset['actionUrl'];
                         var link = $(this);
                         var trTable = $(this).parents('tr');
                         link.addClass("loading");
@@ -283,9 +281,8 @@
                         });
                     });
 
-                    $('a.cancelAcceptBtn').click(function (e) {
-                        e.preventDefault();
-                        var url = this.href;
+                    $('.cancelAcceptBtn').click(function (e) {
+                        var url = this.dataset['actionUrl'];
                         var link = $(this);
                         var trTable = $(this).parents('tr');
                         link.addClass("loading");
@@ -300,9 +297,8 @@
                         });
                     });
 
-                    $('a.cancelRefuseBtn').click(function (e) {
-                        e.preventDefault();
-                        var url = this.href;
+                    $('.cancelRefuseBtn').click(function (e) {
+                        var url = this.dataset['actionUrl'];
                         var link = $(this);
                         link.addClass("loading");
                         var trTable = $(this).parents('tr');

--- a/app/views/GoldenTicketAdmin/showGoldenTicketVotes.scala.html
+++ b/app/views/GoldenTicketAdmin/showGoldenTicketVotes.scala.html
@@ -1,4 +1,4 @@
-@(allVotes:List[(models.Proposal,(models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev))])(implicit lang: Lang, flash: Flash, req:RequestHeader)
+@(allVotes:List[(models.Proposal,(models.Review.Score, models.Review.TotalVoter, models.Review.TotalAbst, models.Review.AverageNote, models.Review.StandardDev))], allApprovedProposalIds: Set[String], allRejectedProposalIds: Set[String])(implicit lang: Lang, flash: Flash, req:RequestHeader)
 
 @main("All votes") {
 
@@ -36,9 +36,7 @@
                         </thead>
                         <tbody>
                             @allVotes.map { case (proposal, voteAndTotalVotes) =>
-                                @defining(ApprovedProposal.isRefused(proposal.id, proposal.talkType.id)){refused=>
-                                @defining(ApprovedProposal.isApproved(proposal.id, proposal.talkType.id)){approved=>
-                                <tr class="preselected_@approved refused_@refused">
+                                <tr data-external-state="@proposal.state.code" data-internal-state="@if(allApprovedProposalIds.contains(proposal.id)){accepted}else{@if(allRejectedProposalIds.contains(proposal.id)){rejected}else{submitted}}">
                                     <td class="number_table"></td>
                                     <td class="average_table">
                                     @defining(voteAndTotalVotes._4.n) { average =>
@@ -81,8 +79,6 @@
                                     </td>
                                     <td>@proposal.lang</td>
                                 </tr>
-                                }
-                                }
                             }
                         </tbody>
                     </table>


### PR DESCRIPTION
This PR integrates both #314 and #315 and provides multiple additions : 
- _(from #314)_ : Add a new line for approved/declined/remaining stat on all votes screen, in order to calculate these stats on clientside (without refresh)
    _I kept the serverside computation just in case there might be a regression (I tested the computation locally, even with declined talks, but in case I missed something...) ... once we will be reassured of the validity of this number (maybe after next evening's deliberation meeting), we might remove the serverside computation statistics_  
    ![image](https://user-images.githubusercontent.com/603815/214240543-45f6e1a9-63ff-4b2c-9da6-6ffdb27e0b12.png)

- _(from #315)_ : remove href on allvotes action button, because for some reasons (I don't know why), `preventDefault()` didn't worked during last deliberation meeting when @aheritier clicked on it (click was sometimes triggering browser navigation on `href` url). 
    I replaced href with a data-action-url instead, so that nothing happens on click.

- A sticky header with overall statistics is added when we scroll down on `all votes` screen : 

<img width="1628" alt="All_votes_-_Devoxx_France_2023" src="https://user-images.githubusercontent.com/603815/214202543-b82390dc-6387-4ed2-8372-ea6eea51b189.png">

- Fixed action buttons display rules on `all votes` screen (prior to this change, we had some weird behaviour, particularly when cancelling accepted/refused talks, where buttons' `sent` state was kept after cancellation)
- I assume we should have Redis performance improvement as Redis was called twice **per displayed proposal** to gather its accepted/refused status (the fix now calls Redis only twice **for every proposals**, in the controller)
- Proposal action buttons & table row background are now based on proposal's internal (= not communicated to authors) status and external (= communicated to authors) statuses. `pre-accepted` and `pre-rejected` tags are now displayed based on overall line state, instead of serverside's accepted/rejected status (this allows to display them without needing a full page refresh).
  _(this item has been generalized on every screens displaying a list of proposals in CFP Admin section, given that CSS classes are shared across those pages)_
- Accepted talks count are now displayed in front of every speakers on `all votes` screen. This has been done without adding a single Redis call compared to the actual implementation (this comes to an extra in-memory computation based on all fetched Proposals from Redis .. but shouldn't take a long time to process). These number are dynamically refreshed, clientside, when we accept new talks (this is also refreshed on acceptance cancelation)
    _Note: BOFs are excluded from this count_

<img width="1408" alt="All_votes_-_Devoxx_France_2023" src="https://user-images.githubusercontent.com/603815/214203351-c82763aa-014a-495b-b1b4-4b41953cf24a.png">
