### PR TITLE
fix acceptedProposalIdsPerSpeakerId to use proposal private state and not public one

### DIFF
--- a/app/controllers/CFPAdmin.scala
+++ b/app/controllers/CFPAdmin.scala
@@ -528,7 +528,7 @@ object CFPAdmin extends SecureCFPController {
 
       val acceptedProposalIdsPerSpeakerId = allProposals.filter{
           case(_, proposal) =>
-            proposal.state.code == ProposalState.ACCEPTED.code && proposal.talkType.id != ConferenceProposalTypes.BOF.id
+            allApprovedProposalIds.contains(proposal.id) && proposal.talkType.id != ConferenceProposalTypes.BOF.id
         }.map { case (_, acceptedProposal: Proposal) => acceptedProposal.allSpeakers.map { speaker => (acceptedProposal, speaker) } }
         .flatten
         .groupBy(_._2.uuid)


### PR DESCRIPTION
This is a bug : while deliberation occurs, we should take private status and not public one in order to take pre-accepted state into consideration