### PR TITLE
Improving allvotes sticky header height

### DIFF
--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -75,18 +75,21 @@
                 }
             </div>
             <div class="col-md-12 mt-2" id="sticky-header">
-                <small><strong>Serverside overall stats</strong></small> :
-                <span class="badge badge-success">@allApprovedProposalIds.size approved</span> <span class="badge badge-declined">
-                    - @declinedTotal declined</span> <span class="badge badge-warning">
-                    = @remainingIncludingDeclined remaining</span>
-                <br>
+                <div class="hidden used-for-debug-purposes-only">
+                    <small><strong>Serverside overall stats</strong></small> :
+                    <span class="badge badge-success">@allApprovedProposalIds.size approved</span> <span class="badge badge-declined">
+                        - @declinedTotal declined</span> <span class="badge badge-warning">
+                        = @remainingIncludingDeclined remaining</span>
+                </div>
+                <small><strong>Overall stats</strong></small> :
                 @if(selectedTrack=="all") {
-                    <small><strong>Clientside overall stats</strong></small> :
                     <span class="badge badge-success"><span id="totalAcceptedProposals"></span> approved</span> <span class="badge badge-declined">
                         - <span id="totalDeclinedProposals"></span> declined</span> <span class="badge badge-warning">
                         = <span id="totalRemainingProposals"></span> remaining</span>
-                    <br/>
+                } else {
+                    <small><em>Stats are not available when filtering on specific track</em></small>
                 }
+                <br>
                 <small><strong>All proposals</strong></small>:
                     @for((trackLabel: String, proposals: List[Proposal]) <- allVotes.map(_._1).groupBy{ proposal => Messages(proposal.track.label) }.toList.sortBy(-_._2.size)) {
                         <span class="badge badge-info">@trackLabel: @proposals.size (@{(proposals.size.toFloat*100/allVotes.size).round}%)</span>

--- a/app/views/CFPAdmin/allVotes.scala.html
+++ b/app/views/CFPAdmin/allVotes.scala.html
@@ -104,7 +104,7 @@
 
             <div class="col-md-12">
                 <small>All proposals with at least one vote, with state set to SUBMITTED/APPROVED/ACCEPTED/BACKUP</small>
-                <small>If you just created a proposal and it's not listed here : please add a vote.</small>
+                <small>If you just created a proposal and it's not listed here : <span style="color: red">please cast a vote</span>.</small>
 
                 <table id="allProposals" class="compact cell-border order-column">
                     <thead>


### PR DESCRIPTION
Small improvement removing serverside calculated statistics as it seemed like there was no bug during second deliberation meeting.

I'm keeping serverside generated stats in the DOM anyway, but hiding them to reduce sticky header size

Before:
<img width="1633" alt="Cursor_and_All_votes_-_Devoxx_France_2023" src="https://user-images.githubusercontent.com/603815/216812547-34a55812-bac3-49df-a1b3-0f81cc7164b9.png">

After:
<img width="1632" alt="All_votes_-_Devoxx_France_2023" src="https://user-images.githubusercontent.com/603815/216812450-699e01c3-0aaa-461b-bf0c-36e015835793.png">

PS: I also made a little bit more proeminent the fact that proposals with no vote will not appear in the list :
<img width="1154" alt="Cursor_and_All_votes_-_Devoxx_France_2023" src="https://user-images.githubusercontent.com/603815/216812633-92cd1b5e-5f27-4096-ba62-43cfa2bfdd90.png">
