### PR TITLE
fix: Don't use the talkType label

### DIFF
--- a/app/views/Publisher/showProposal.scala.html
+++ b/app/views/Publisher/showProposal.scala.html
@@ -60,7 +60,7 @@
                             <tbody class="divide-y divide-gray-200">
                             <tr>
                                 <th  scope="row" class="px-3 py-2 text-right">@Messages("showProposal.talkType")</th>
-                                <td class="text-gray-800">@Messages(proposal.talkType.label)</td>
+                                <td class="text-gray-800"><a href="@routes.Publisher.showByTalkType(proposal.talkType.id)">@Messages(proposal.talkType.id)</a></td>
                             </tr>
                             <tr>
                                 <th  scope="row" class="px-3 py-2 text-right">Track</th>


### PR DESCRIPTION
The label contains a warning about "invitations only"

(Also add link to navigate back to the list of all talks of the same type)

# Before

![Screenshot 2023-04-10 at 16 08 02](https://user-images.githubusercontent.com/174600/230917601-2b4c6fc8-a353-4cf9-8a10-bd6685f0dfb4.png)


# After

![Screenshot 2023-04-10 at 16 08 31](https://user-images.githubusercontent.com/174600/230917682-366bac75-db41-44cc-a927-fbcda232707c.png)
